### PR TITLE
В методах Use() тип возврата заменен на WebApplication

### DIFF
--- a/src/AndreyAkaSkif.ServiceDefaults.OpenApi/OpenApiConfigureExtensions.cs
+++ b/src/AndreyAkaSkif.ServiceDefaults.OpenApi/OpenApiConfigureExtensions.cs
@@ -37,7 +37,7 @@ public static class OpenApiConfigureExtensions
     /// </remarks>
     /// <param name="app">Экземпляр <see cref="WebApplication"/>.</param>
     /// <returns>Тот же экземпляр <see cref="IApplicationBuilder"/> для поддержки цепочки вызовов.</returns>
-    public static IApplicationBuilder UseDefaultOpenApi(this WebApplication app)
+    public static WebApplication UseDefaultOpenApi(this WebApplication app)
     {
         if (app.Environment.IsDevelopment())
             app.MapOpenApi();

--- a/src/AndreyAkaSkif.ServiceDefaults.Serilog/LoggingConfigureExtensions.cs
+++ b/src/AndreyAkaSkif.ServiceDefaults.Serilog/LoggingConfigureExtensions.cs
@@ -9,8 +9,7 @@ namespace AndreyAkaSkif.ServiceDefaults.Logging.Serilog;
 public static class LoggingConfigureExtensions
 {
     /// <summary>
-    /// Настраивает Serilog как систему логирования для приложения, 
-    /// используя конфигурацию из <see cref="IHostApplicationBuilder.Configuration"/>.
+    /// Добавляет и настраивает Serilog как систему логирования для приложения
     /// </summary>
     /// <remarks>
     /// В файле конфигурации приложения "appsettings.json" требуется секция "Serilog"
@@ -21,7 +20,7 @@ public static class LoggingConfigureExtensions
     /// <returns>
     /// Тот же экземпляр <see cref="IHostApplicationBuilder"/> для поддержки цепочки вызовов.
     /// </returns>
-    public static IHostApplicationBuilder SetupSerilogLogging(this IHostApplicationBuilder builder)
+    public static IHostApplicationBuilder AddConfiguredLoggingViaSerilog(this IHostApplicationBuilder builder)
     {
         var logger = new LoggerConfiguration()
             .ReadFrom.Configuration(builder.Configuration)

--- a/src/AndreyAkaSkif.ServiceDefaults.Swagger/ConfiguredOpenApiViaSwaggerConfigureExtensions.cs
+++ b/src/AndreyAkaSkif.ServiceDefaults.Swagger/ConfiguredOpenApiViaSwaggerConfigureExtensions.cs
@@ -80,7 +80,7 @@ public static class ConfiguredOpenApiViaSwaggerConfigureExtensions
     /// <exception cref="ArgumentException">
     /// Выбрасывается, если секция "SwaggerAppSettings" отсутствует в конфигурации или содержит некорректные данные.
     /// </exception>
-    public static IApplicationBuilder UseConfiguredOpenApiViaSwagger(this WebApplication app)
+    public static WebApplication UseConfiguredOpenApiViaSwagger(this WebApplication app)
     {
         if (!app.Environment.IsDevelopment())
             return app;

--- a/src/AndreyAkaSkif.ServiceDefaults.Swagger/DefaultOpenApiViaSwaggerConfigureExtensions.cs
+++ b/src/AndreyAkaSkif.ServiceDefaults.Swagger/DefaultOpenApiViaSwaggerConfigureExtensions.cs
@@ -37,7 +37,7 @@ public static class DefaultOpenApiViaSwaggerConfigureExtensions
     /// </remarks>
     /// <param name="app">Экземпляр <see cref="WebApplication"/>.</param>
     /// <returns>Тот же экземпляр <see cref="IApplicationBuilder"/> для поддержки цепочки вызовов.</returns>
-    public static IApplicationBuilder UseDefaultOpenApiViaSwagger(this WebApplication app)
+    public static WebApplication UseDefaultOpenApiViaSwagger(this WebApplication app)
     {
         if (app.Environment.IsDevelopment())
         {

--- a/src/AndreyAkaSkif.ServiceDefaults/Cors/ConfiguredCorsExtensions.cs
+++ b/src/AndreyAkaSkif.ServiceDefaults/Cors/ConfiguredCorsExtensions.cs
@@ -6,33 +6,12 @@ using Microsoft.Extensions.Hosting;
 namespace AndreyAkaSkif.ServiceDefaults.Cors;
 
 /// <summary>
-/// Методы расширения для регистрации политик CORS в DI-контейнере.
+/// Методы расширения для регистрации конфигурируемых политик CORS в DI-контейнере
 /// </summary>
-public static class CorsExtensions
+public static class ConfiguredCorsExtensions
 {
-    private const string ALLOW_ALL_POLICY_NAME = "AllowAll";
-
     /// <summary>
-    /// Добавить политику CORS, разрешающую все источники
-    /// </summary>
-    public static IHostApplicationBuilder AddPermissiveCorsPolicy(this IHostApplicationBuilder builder)
-    {
-        builder.Services.AddCors(options =>
-        {
-            options.AddPolicy(
-                ALLOW_ALL_POLICY_NAME,
-                policy => policy
-                    .AllowAnyOrigin()
-                    .AllowAnyMethod()
-                    .AllowAnyHeader()
-            );
-        });
-
-        return builder;
-    }
-
-    /// <summary>
-    /// Добавить политику CORS, настроенную через конфигурацию.
+    /// Добавить политику CORS, настроенную через конфигурацию
     /// </summary>
     /// <remarks>
     /// Требует секцию конфигурации "CorsPolicy" следующего вида:
@@ -65,22 +44,12 @@ public static class CorsExtensions
     }
 
     /// <summary>
-    /// Использовать политику CORS, разрешающую все источники
-    /// </summary>
-    public static IApplicationBuilder UsePermissiveCorsPolicy(this WebApplication app)
-    {
-        app.UseCors(ALLOW_ALL_POLICY_NAME);
-
-        return app;
-    }
-
-    /// <summary>
     /// Использовать политику CORS, настроенную через конфигурацию
     /// </summary>
     /// <remarks>
     /// Требует секцию конфигурации "CorsPolicy"
     /// </remarks>
-    public static IApplicationBuilder UseConfiguredCorsPolicy(this WebApplication app)
+    public static WebApplication UseConfiguredCorsPolicy(this WebApplication app)
     {
         var сorsPolicy = app.Configuration.CreateValidated<CorsPolicy>();
         app.UseCors(сorsPolicy.Name);

--- a/src/AndreyAkaSkif.ServiceDefaults/Cors/PermissiveCorsExtensions.cs
+++ b/src/AndreyAkaSkif.ServiceDefaults/Cors/PermissiveCorsExtensions.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace AndreyAkaSkif.ServiceDefaults.Cors;
+
+/// <summary>
+/// Методы расширения для регистрации разрешительных политик CORS в DI-контейнере
+/// </summary>
+public static class PermissiveCorsExtensions
+{
+    private const string ALLOW_ALL_POLICY_NAME = "AllowAll";
+
+    /// <summary>
+    /// Добавить политику CORS, разрешающую все источники
+    /// </summary>
+    public static IHostApplicationBuilder AddPermissiveCorsPolicy(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddCors(options =>
+        {
+            options.AddPolicy(
+                ALLOW_ALL_POLICY_NAME,
+                policy => policy
+                    .AllowAnyOrigin()
+                    .AllowAnyMethod()
+                    .AllowAnyHeader()
+            );
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Использовать политику CORS, разрешающую все источники
+    /// </summary>
+    public static WebApplication UsePermissiveCorsPolicy(this WebApplication app)
+    {
+        app.UseCors(ALLOW_ALL_POLICY_NAME);
+
+        return app;
+    }
+}


### PR DESCRIPTION
* тип возврата заменен на WebApplication
* класс расширений CORS разделен на конфигурируемые и разрешительные методы
* изменения в xml-комментариях

https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/issues/17