### PR TITLE
build: .editorconfig по эталону, CA1707 через severity

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,19 +1,46 @@
+# Не искать .editorconfig в родительских каталогах
 root = true
 
-# All files
+# Значения по умолчанию для всех файлов
 [*]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
-indent_size = 4
 indent_style = space
-tab_width = 4
+indent_size = 4
+max_line_length = 100
 
-# XML project files
-[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+# .NET
+[*.{cs,vb}]
+indent_size = 4
+
+[*.{csproj,vbproj,fsproj,props,targets}]
 indent_size = 2
 
-# XML config files
-[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+[*.{xml,config,resx,settings}]
 indent_size = 2
+
+[*.{sln,slnx}]
+indent_style = tab
+
+# JSON / YAML / Markdown
+[*.json]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+max_line_length = 0
+
+# Windows-скрипты
+[*.{bat,cmd,ps1}]
+end_of_line = crlf
+
+# Тесты: подчёркивания в именах тест-методов — идиома xUnit (имя теста читается как
+# фраза в выводе раннера, это не вызываемая API-поверхность), правило именования тут
+# не по адресу. Остальные анализаторы остаются в силе.
+[tests/**/*.cs]
+dotnet_diagnostic.CA1707.severity = none

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -13,9 +13,5 @@
     <IsPackable>False</IsPackable>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- CA1707: подчёркивания в именах тестов — это принятая конвенция
-         Method_ShouldDoX_WhenY, переименовывать не нужно -->
-    <NoWarn>$(NoWarn);CA1707</NoWarn>
-  </PropertyGroup>
+  <!-- CA1707 для тестов отключён в корневом .editorconfig, секция [tests/**/*.cs] -->
 </Project>


### PR DESCRIPTION
Дополняет .editorconfig до уровня эталона andrey-aka-skif-service-result:
max_line_length, отступы для sln/slnx, json и yaml, послабления для md,
crlf для Windows-скриптов.

CA1707 для тестов перенесён из NoWarn в tests/Directory.Build.props
в секцию [tests/**/*.cs] .editorconfig — правило стало точечным, по пути,
и живёт в одном месте. Проверено: со снятой секцией сборка тестов даёт
5 предупреждений CA1707, с ней — ноль.

Существующий код под max_line_length = 100 не переформатирован:
это редакторская подсказка, на сборку не влияет. Переформатирование —
отдельная задача.

Closes #47