### PR TITLE
fix: контракт HealthCheck endpoint для оркестратора

### DIFF
--- a/src/AndreyAkaSkif.ServiceDefaults.Swagger/HealthChecksDocumentFilter.cs
+++ b/src/AndreyAkaSkif.ServiceDefaults.Swagger/HealthChecksDocumentFilter.cs
@@ -26,12 +26,13 @@ public class HealthChecksDocumentFilter : IDocumentFilter
         {
             Tags = [new() { Name = "Health" }],
             Summary = "Health Check",
-            Description = $"Отображение конечной точки {HealthCheckDefaults.Endpoint}, добавляемой через HealthCheck middleware",
+            Description = $"Проверка жизнеспособности приложения для оркестратора. "
+                + $"Отображение конечной точки {HealthCheckDefaults.Endpoint}, добавляемой через HealthCheck middleware",
             Responses = new OpenApiResponses
             {
                 ["200"] = new OpenApiResponse
                 {
-                    Description = "Healthy or Degraded",
+                    Description = "Healthy",
                     Content =
                     {
                         ["text/plain"] = new OpenApiMediaType
@@ -41,26 +42,7 @@ public class HealthChecksDocumentFilter : IDocumentFilter
                                 Type = "string",
                                 Enum =
                                 [
-                                    new OpenApiString("Healthy"),
-                                    new OpenApiString("Degraded")
-                                ]
-                            }
-                        }
-                    }
-                },
-                ["503"] = new OpenApiResponse
-                {
-                    Description = "Unhealthy",
-                    Content =
-                    {
-                        ["text/plain"] = new OpenApiMediaType
-                        {
-                            Schema = new OpenApiSchema
-                            {
-                                Type = "string",
-                                Enum =
-                                [
-                                    new OpenApiString("Unhealthy")
+                                    new OpenApiString("Healthy")
                                 ]
                             }
                         }

--- a/src/AndreyAkaSkif.ServiceDefaults.Swagger/HealthChecksExtensions.cs
+++ b/src/AndreyAkaSkif.ServiceDefaults.Swagger/HealthChecksExtensions.cs
@@ -10,27 +10,32 @@ namespace AndreyAkaSkif.ServiceDefaults.Swagger;
 public static class HealthChecksExtensions
 {
     /// <summary>
-    /// Добавить HealthCheck сервисы и отображение HealthCheck конечной точки в Swagger
+    /// Добавить сервисы конечной точки проверки жизнеспособности приложения
+    /// и её отображение в Swagger
     /// </summary>
-    public static IHostApplicationBuilder AddHealthChecksWithSwagger(this IHostApplicationBuilder builder)
+    public static IHostApplicationBuilder AddHealthCheckEndpointWithSwagger(this IHostApplicationBuilder builder)
     {
-        builder.AddHealthChecks();
-        builder.AddHealthChecksSwagger();
+        builder.AddHealthCheckEndpoint();
+        builder.AddHealthCheckEndpointSwagger();
 
         return builder;
     }
 
     /// <summary>
-    /// Добавить в Swagger отображение HealthCheck конечной точки
+    /// Добавить в Swagger отображение конечной точки проверки жизнеспособности приложения
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// В документацию добавляется конечная точка <c>/health</c>
+    /// (константа <see cref="HealthCheckDefaults.Endpoint"/>) с единственным ответом <c>200 Healthy</c>
+    /// </para>
     /// <para>
     /// Обратить внимание, что метод только добавляет описание конечной точки в документацию Swagger.
     /// Для функционирования конечной точки необходимо включить HealthCheck сервисы и добавить HealthCheck middleware в конвейер обработки запросов.
     /// В ином случае конечная точка будет неактивна. Соответствующий пункт Swagger UI будет возвращать ошибку 404 Not Found
     /// </para>
     /// </remarks>
-    public static IHostApplicationBuilder AddHealthChecksSwagger(this IHostApplicationBuilder builder)
+    public static IHostApplicationBuilder AddHealthCheckEndpointSwagger(this IHostApplicationBuilder builder)
     {
         builder.Services.AddSwaggerGen(options =>
         {

--- a/src/AndreyAkaSkif.ServiceDefaults.Swagger/README.md
+++ b/src/AndreyAkaSkif.ServiceDefaults.Swagger/README.md
@@ -10,7 +10,7 @@ dotnet add package AndeyAkaSkif.ServiceDefaults.Swagger
 ## Возможности
 - конфигурация OpenAPI спецификации и Swagger UI с параметрами по умолчанию (`AddDefaultOpenApiViaSwagger()`, `UseDefaultOpenApiViaSwagger()`);
 - конфигурация OpenAPI спецификации и Swagger UI на основе конфигурации (`AddConfiguredOpenApiViaSwagger()`, `UseConfiguredOpenApiViaSwagger()`)
-- отображение конечной точки HealthCheck в Swagger UI (`AddHealthChecksSwagger()`).
+- отображение конечной точки проверки жизнеспособности в Swagger UI (`AddHealthCheckEndpointSwagger()`).
 
 ## Пример использования
 ```csharp
@@ -18,19 +18,19 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.AddDefaultOpenApiViaSwagger();
 
-// раздельная регистрация Health Checks сервисов и отображение конечной точки в Swagger UI
-builder.AddHealthChecks();
-builder.AddHealthChecksSwagger();
+// раздельная регистрация сервисов конечной точки и её отображения в Swagger UI
+builder.AddHealthCheckEndpoint();
+builder.AddHealthCheckEndpointSwagger();
 
-// или единая регистрация Health Checks сервисов и отображение конечной точки в Swagger UI
-builder.AddHealthChecksWithSwagger();
+// или единая регистрация сервисов конечной точки и её отображения в Swagger UI
+builder.AddHealthCheckEndpointWithSwagger();
 
 var app = builder.Build();
 
 app.UseDefaultOpenApiViaSwagger();
 
-// добавление конечной точки HealthCheck в конвейер обработки запросов
-app.MapHealthChecksEndpoint();
+// добавление конечной точки проверки жизнеспособности в конвейер обработки запросов
+app.MapHealthCheckEndpoint();
 
 app.Run();
 ```
@@ -57,26 +57,33 @@ app.Run();
 При использовании методов из библиотеки `ServiceDefaults.Swagger` всегда устанавливается пакет `Swashbuckle.AspNetCore.Annotations`.
 Даже, если в проекте не используются MVC контроллеры, а только Minimal Api.
 
-### Отображение конечной точки HealthCheck в Swagger UI
-Метод `AddHealthChecksSwagger()` только добавляет описание конечной точки в документацию Swagger.
+### Отображение конечной точки проверки жизнеспособности в Swagger UI
+Метод `AddHealthCheckEndpointSwagger()` только добавляет описание конечной точки в документацию Swagger.
 Для функционирования конечной точки необходимо включить HealthCheck сервисы и добавить HealthCheck middleware в конвейер обработки запросов
 В ином случае конечная точка будет неактивна. Соответствующий пункт Swagger UI будет возвращать ошибку `404 Not Found`.
-Включение HealthCheck сервисов осуществляется с помощью метода `AddHealthChecks()` из пакета `AndreyAkaSkif.ServiceDefaults`.
-Добавление HealthCheck middleware осуществляется с помощью метода `MapHealthChecksEndpoint()` из пакета `AndreyAkaSkif.ServiceDefaults`:
+Включение HealthCheck сервисов осуществляется с помощью метода `AddHealthCheckEndpoint()` из пакета `AndreyAkaSkif.ServiceDefaults`.
+Добавление HealthCheck middleware осуществляется с помощью метода `MapHealthCheckEndpoint()` из пакета `AndreyAkaSkif.ServiceDefaults`:
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
 
-builder.AddHealthChecks();
-builder.AddHealthChecksSwagger();
+builder.AddHealthCheckEndpoint();
+builder.AddHealthCheckEndpointSwagger();
 
 var app = builder.Build();
 
-app.MapHealthChecksEndpoint();
+app.MapHealthCheckEndpoint();
 
 app.Run();
 ```
 
-Альтернативно, можно использовать единый метод `AddHealthChecksWithSwagger()`, который включает регистрацию HealthCheck сервисов.
+Альтернативно, можно использовать единый метод `AddHealthCheckEndpointWithSwagger()`, который включает регистрацию HealthCheck сервисов.
+
+В Swagger UI описывается конечная точка `/health` (константа `HealthCheckDefaults.Endpoint`
+из пакета `AndreyAkaSkif.ServiceDefaults`) с единственным ответом `200 Healthy`: конечная точка
+не выполняет зарегистрированные проверки и отвечает успехом самим фактом ответа приложения.
+Адрес не конфигурируется — он должен совпадать с адресом, который регистрирует
+`MapHealthCheckEndpoint()`.
+Подробнее о контракте — в README пакета `AndreyAkaSkif.ServiceDefaults`.
 
 ## Документация пакета
 Полное описание пакета и другие примеры:

--- a/src/AndreyAkaSkif.ServiceDefaults/HealthChecking/HealthCheckingExtensions.cs
+++ b/src/AndreyAkaSkif.ServiceDefaults/HealthChecking/HealthCheckingExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -10,12 +11,21 @@ namespace AndreyAkaSkif.ServiceDefaults.HealthChecking;
 public static class HealthCheckingExtensions
 {
     /// <summary>
-    /// Добавить HealthCheck сервисы
+    /// Добавить сервисы, необходимые для конечной точки проверки жизнеспособности приложения
     /// </summary>
     /// <remarks>
-    /// Метод является унифицированной оберткой над вызовом <c>builder.Services.AddHealthChecks()</c>
+    /// <para>
+    /// Метод регистрирует минимальную инфраструктуру ASP.NET Core Health Checks, достаточную
+    /// для использования Docker Compose, Kubernetes или другого оркестратора.
+    /// Саму конечную точку <c>/health</c> добавляет <see cref="MapHealthCheckEndpoint"/>
+    /// </para>
+    /// <para>
+    /// Метод не предназначен для регистрации пользовательских проверок.
+    /// Для добавления проверок БД, Redis и других зависимостей используйте стандартный API
+    /// <c>builder.Services.AddHealthChecks()</c>
+    /// </para>
     /// </remarks>
-    public static IHostApplicationBuilder AddHealthChecks(this IHostApplicationBuilder builder)
+    public static IHostApplicationBuilder AddHealthCheckEndpoint(this IHostApplicationBuilder builder)
     {
         builder.Services.AddHealthChecks();
 
@@ -23,11 +33,31 @@ public static class HealthCheckingExtensions
     }
 
     /// <summary>
-    /// Добавить HealthCheck middleware
+    /// Добавить конечную точку проверки жизнеспособности приложения по адресу <c>/health</c>
     /// </summary>
-    public static WebApplication MapHealthChecksEndpoint(this WebApplication app)
+    /// <remarks>
+    /// <para>
+    /// Конечная точка позволяет оркестратору определить, что приложение запустилось и принимает
+    /// HTTP-запросы. Она не исполняет зарегистрированные проверки и отвечает <c>200 Healthy</c>
+    /// самим фактом ответа приложения.
+    /// </para>
+    /// <para>
+    /// Адрес конечной точки задан константой <see cref="HealthCheckDefaults.Endpoint"/>
+    /// и не конфигурируется: то же значение использует фильтр документации Swagger
+    /// из пакета <c>AndreyAkaSkif.ServiceDefaults.Swagger</c>
+    /// </para>
+    /// <para>
+    /// Проверки, добавленные через стандартный API <c>builder.Services.AddHealthChecks()</c>,
+    /// сознательно не попадают в эту конечную точку: недоступность БД или другой зависимости
+    /// не является поводом для перезапуска работающего приложения.
+    /// Для таких проверок регистрируйте отдельную конечную точку вызовом <c>app.MapHealthChecks()</c>
+    /// </para>
+    /// </remarks>
+    public static WebApplication MapHealthCheckEndpoint(this WebApplication app)
     {
-        app.MapHealthChecks(HealthCheckDefaults.Endpoint);
+        app.MapHealthChecks(
+            HealthCheckDefaults.Endpoint,
+            new HealthCheckOptions { Predicate = _ => false });
 
         return app;
     }

--- a/src/AndreyAkaSkif.ServiceDefaults/README.md
+++ b/src/AndreyAkaSkif.ServiceDefaults/README.md
@@ -15,7 +15,7 @@ dotnet add package AndreyAkaSkif.ServiceDefaults
     - настройка политик CORS
     - саброутинг (PathBase)
     - обработка ошибок с использованием ProblemDetails
-    - упрощенный Health Checks (конечная точка `/health`)
+    - конечная точка проверки жизнеспособности приложения для оркестратора (`/health`)
 - Регистрация конфигураций и аргументов
     - упрощённая регистрация валидируемых настроек в DI контейнере через единый extension-метод
     - упрощенная регистрация произвольного экземпляра класса в DI контейнере через единый extension-метод
@@ -26,7 +26,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.AddConfiguredCorsPolicy();      // добавление политики CORS, настроенной через конфигурацию
 builder.AddExtendedErrorHandling();     // регистрация стандартной обработки ошибок с использованием ProblemDetails
-builder.AddHealthChecks();              // регистрация Health Checks сервисов (унифицированная обертка над builder.Services.AddHealthChecks())
+builder.AddHealthCheckEndpoint();       // регистрация сервисов конечной точки проверки жизнеспособности приложения
 
 builder.AddServiceArgFromValidatedSettingsObject<ExampleSettingsArgs>();    // регистрация валидированного объекта настроек как singleton в DI-контейнере
 
@@ -35,9 +35,42 @@ var app = builder.Build();
 app.UseConfiguredCorsPolicy();          // подключение политики CORS, настроенной через конфигурацию
 app.UseErrorHandling();                 // подключение промежуточного ПО для обработки исключений в конвейере запросов
 app.UseConfiguredPathBase();            // добавление базового пути на основе конфигурации
-app.MapHealthChecksEndpoint();          // добавление Health Checks конечной точки (/health)
+app.MapHealthCheckEndpoint();           // добавление конечной точки проверки жизнеспособности (/health)
 
 app.Run();
+```
+
+## Health Checks
+Пара методов `AddHealthCheckEndpoint()` / `MapHealthCheckEndpoint()` регистрирует минимальную
+инфраструктуру ASP.NET Core Health Checks и одну конечную точку `/health`, достаточную для
+использования Docker Compose, Kubernetes или другого оркестратора.
+
+Назначение конечной точки — сообщить оркестратору, что приложение запустилось и принимает
+HTTP-запросы. Никаких проверок она не выполняет и отвечает `200 Healthy` самим фактом ответа
+приложения.
+
+Адрес конечной точки — `/health`. Он задан константой `HealthCheckDefaults.Endpoint`
+и не конфигурируется: то же значение использует фильтр документации Swagger из пакета
+`AndreyAkaSkif.ServiceDefaults.Swagger`, и параметризация пути развела бы их между собой.
+Если нужен другой адрес, добавьте свою конечную точку вызовом `app.MapHealthChecks()`
+вместо `MapHealthCheckEndpoint()`.
+
+Методы **не предназначены** для регистрации пользовательских проверок.
+Для добавления проверок БД, Redis и других зависимостей используйте стандартный API
+`builder.Services.AddHealthChecks()`.
+Такие проверки сознательно не попадают в `/health`: недоступность зависимости не является поводом
+перезапускать работающее приложение. Если проверки зависимостей нужно опубликовать, добавьте
+для них отдельную конечную точку вызовом `app.MapHealthChecks()`:
+
+```csharp
+builder.AddHealthCheckEndpoint();                       // /health — приложение живо
+builder.Services.AddHealthChecks()                      // проверки зависимостей
+       .AddNpgSql(connectionString);
+
+var app = builder.Build();
+
+app.MapHealthCheckEndpoint();                           // /health
+app.MapHealthChecks("/ready");                          // /ready — зависимости доступны
 ```
 
 ## ⚠️ Важно


### PR DESCRIPTION
AddHealthChecks/MapHealthChecksEndpoint переименованы в AddHealthCheckEndpoint/MapHealthCheckEndpoint. Endpoint регистрируется с Predicate = _ => false: пользовательские проверки, добавленные через Services.AddHealthChecks(), больше не влияют на /health.

В документации отражены назначение конечной точки, её адрес /health и то, что адрес не конфигурируется.

В пакете Swagger методы приведены к той же схеме, из документации конечной точки убраны ответы Degraded и 503.

Closes #50