### PR TITLE
fix: убрать неиспользуемый Swashbuckle из трёх пакетов

### DIFF
--- a/src/AndreyAkaSkif.ServiceDefaults.OpenApi/AndreyAkaSkif.ServiceDefaults.OpenApi.csproj
+++ b/src/AndreyAkaSkif.ServiceDefaults.OpenApi/AndreyAkaSkif.ServiceDefaults.OpenApi.csproj
@@ -16,10 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <!-- Явная ссылка ради версии: транзитивно приходит Microsoft.OpenApi 2.0.0
          с NU1903 (GHSA-v5pm-xwqc-g5wc), первая исправленная версия — 2.7.5 -->

--- a/src/AndreyAkaSkif.ServiceDefaults.PostgreSQL/AndreyAkaSkif.ServiceDefaults.PostgreSQL.csproj
+++ b/src/AndreyAkaSkif.ServiceDefaults.PostgreSQL/AndreyAkaSkif.ServiceDefaults.PostgreSQL.csproj
@@ -16,11 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <!-- IHostApplicationBuilder. Раньше приходил транзитивно из Swashbuckle -->
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/AndreyAkaSkif.ServiceDefaults.Serilog/AndreyAkaSkif.ServiceDefaults.Serilog.csproj
+++ b/src/AndreyAkaSkif.ServiceDefaults.Serilog/AndreyAkaSkif.ServiceDefaults.Serilog.csproj
@@ -16,10 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Serilog.AspNetCore" />
   </ItemGroup>
 


### PR DESCRIPTION
Swashbuckle.AspNetCore ссылался в OpenApi, PostgreSQL и Serilog, где не использовался ни одной строкой кода. Особенно вреден в OpenApi: пакет «OpenAPI без UI» транзитивно тянул потребителю весь Swagger UI.

В PostgreSQL зависимость была не полностью мёртвой: через неё транзитивно приходил Microsoft.Extensions.Hosting.Abstractions с IHostApplicationBuilder. Добавлена явная ссылка на него, версия уже была в Directory.Packages.props.

Closes #51