### PR TITLE
fix: Use* резолвят настройки из DI вместо повторного биндинга

### DIFF
--- a/src/AndreyAkaSkif.ServiceDefaults.Swagger/AndreyAkaSkif.ServiceDefaults.Swagger.csproj
+++ b/src/AndreyAkaSkif.ServiceDefaults.Swagger/AndreyAkaSkif.ServiceDefaults.Swagger.csproj
@@ -16,6 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="AndreyAkaSkif.ServiceDefaults.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" />
   </ItemGroup>

--- a/src/AndreyAkaSkif.ServiceDefaults.Swagger/ConfiguredOpenApiViaSwaggerConfigureExtensions.cs
+++ b/src/AndreyAkaSkif.ServiceDefaults.Swagger/ConfiguredOpenApiViaSwaggerConfigureExtensions.cs
@@ -34,10 +34,8 @@ public static class ConfiguredOpenApiViaSwaggerConfigureExtensions
     /// будет выброшено исключение <see cref="ArgumentException"/>.
     /// </para>
     /// <para>
-    /// <strong>Следует обратить внимание,</strong> что при использовании файлов конфигурации
-    /// секция должна быть указана в основном файле "appsettings.json".
-    /// <strong>Не следует</strong> выносить секцию в файлы, содержащие среду.
-    /// Например, в "appsettings.Development.json".
+    /// Валидированные настройки регистрируются в DI-контейнере,
+    /// откуда их берёт <see cref="UseConfiguredOpenApiViaSwagger"/>.
     /// </para>
     /// <para>
     /// При использовании методов из библиотеки ServiceDefaults.Swagger
@@ -52,6 +50,8 @@ public static class ConfiguredOpenApiViaSwaggerConfigureExtensions
     public static IHostApplicationBuilder AddConfiguredOpenApiViaSwagger(this IHostApplicationBuilder builder)
     {
         var settings = builder.Configuration.CreateValidated<SwaggerAppSettings>();
+
+        builder.AddServiceArg(settings);
 
         builder.Services.AddSwaggerGen(options =>
         {
@@ -83,21 +83,23 @@ public static class ConfiguredOpenApiViaSwaggerConfigureExtensions
     /// <remarks>
     /// <para>
     /// Метод активирует Swagger и Swagger UI только в development среде.
-    /// Для корректной работы требуется наличие валидной секции конфигурации "SwaggerAppSettings".
+    /// Для корректной работы требуется предварительный вызов
+    /// <see cref="AddConfiguredOpenApiViaSwagger"/>: настройки берутся из
+    /// DI-контейнера, конфигурация повторно не читается.
     /// </para>
     /// <para>
     /// Дополнительно настраивает маршрут "/" для автоматического перенаправления на страницу Swagger UI ("/swagger").
     /// </para>
     /// </remarks>
-    /// <exception cref="ArgumentException">
-    /// Выбрасывается, если секция "SwaggerAppSettings" отсутствует в конфигурации или содержит некорректные данные.
+    /// <exception cref="InvalidOperationException">
+    /// Выбрасывается, если <see cref="AddConfiguredOpenApiViaSwagger"/> не был вызван.
     /// </exception>
     public static WebApplication UseConfiguredOpenApiViaSwagger(this WebApplication app)
     {
         if (!app.Environment.IsDevelopment())
             return app;
 
-        var settings = app.Configuration.CreateValidated<SwaggerAppSettings>();
+        var settings = app.Services.GetRequiredService<SwaggerAppSettings>();
 
         app.UseSwagger();
 

--- a/src/AndreyAkaSkif.ServiceDefaults/Cors/ConfiguredCorsExtensions.cs
+++ b/src/AndreyAkaSkif.ServiceDefaults/Cors/ConfiguredCorsExtensions.cs
@@ -24,10 +24,17 @@ public static class ConfiguredCorsExtensions
     ///   ]
     /// }
     /// </code>
+    /// Валидированные настройки регистрируются в DI-контейнере,
+    /// откуда их берёт <see cref="UseConfiguredCorsPolicy"/>.
     /// </remarks>
+    /// <exception cref="ArgumentException">
+    /// Выбрасывается, если секция "CorsPolicy" отсутствует в конфигурации или содержит некорректные данные.
+    /// </exception>
     public static IHostApplicationBuilder AddConfiguredCorsPolicy(this IHostApplicationBuilder builder)
     {
         var corsPolicy = builder.Configuration.CreateValidated<CorsPolicy>();
+
+        builder.AddServiceArg(corsPolicy);
 
         builder.Services.AddCors(options =>
         {
@@ -47,11 +54,15 @@ public static class ConfiguredCorsExtensions
     /// Использовать политику CORS, настроенную через конфигурацию
     /// </summary>
     /// <remarks>
-    /// Требует секцию конфигурации "CorsPolicy"
+    /// Требует предварительного вызова <see cref="AddConfiguredCorsPolicy"/>:
+    /// настройки берутся из DI-контейнера, конфигурация повторно не читается.
     /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Выбрасывается, если <see cref="AddConfiguredCorsPolicy"/> не был вызван.
+    /// </exception>
     public static WebApplication UseConfiguredCorsPolicy(this WebApplication app)
     {
-        var corsPolicy = app.Configuration.CreateValidated<CorsPolicy>();
+        var corsPolicy = app.Services.GetRequiredService<CorsPolicy>();
         app.UseCors(corsPolicy.Name);
 
         return app;

--- a/tests/AndreyAkaSkif.ServiceDefaults.Tests/AndreyAkaSkif.ServiceDefaults.Tests.csproj
+++ b/tests/AndreyAkaSkif.ServiceDefaults.Tests/AndreyAkaSkif.ServiceDefaults.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\AndreyAkaSkif.ServiceDefaults\AndreyAkaSkif.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\..\src\AndreyAkaSkif.ServiceDefaults.Swagger\AndreyAkaSkif.ServiceDefaults.Swagger.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/AndreyAkaSkif.ServiceDefaults.Tests/ConfiguredCorsExtensionsTests.cs
+++ b/tests/AndreyAkaSkif.ServiceDefaults.Tests/ConfiguredCorsExtensionsTests.cs
@@ -1,0 +1,76 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AndreyAkaSkif.ServiceDefaults.Tests;
+
+public class ConfiguredCorsExtensionsTests
+{
+    private static readonly Dictionary<string, string?> ValidConfiguration = new()
+    {
+        ["CorsPolicy:Name"] = "PolicyName",
+        ["CorsPolicy:Origins:0"] = "http://localhost:5001",
+    };
+
+    [Fact]
+    public void AddConfiguredCorsPolicy_ShouldRegisterValidatedSettings_WhenConfigurationIsValid()
+    {
+        // Arrange
+        var builder = CreateBuilderWith(ValidConfiguration);
+
+        // Act
+        builder.AddConfiguredCorsPolicy();
+        using var app = builder.Build();
+
+        // Assert
+        var corsPolicy = app.Services.GetRequiredService<CorsPolicy>();
+        Assert.Equal("PolicyName", corsPolicy.Name);
+        Assert.Equal(["http://localhost:5001"], corsPolicy.Origins);
+    }
+
+    [Fact]
+    public void AddConfiguredCorsPolicy_ShouldThrowArgumentException_WhenConfigurationIsInvalid()
+    {
+        // Arrange
+        var builder = CreateBuilderWith(new Dictionary<string, string?>
+        {
+            ["CorsPolicy:Name"] = "PolicyName",
+        });
+
+        // Act & Assert
+        // валидация выполняется в момент регистрации, а не при разрешении сервиса
+        Assert.Throws<ArgumentException>(() => builder.AddConfiguredCorsPolicy());
+    }
+
+    [Fact]
+    public void UseConfiguredCorsPolicy_ShouldNotThrow_WhenAddWasCalled()
+    {
+        // Arrange
+        var builder = CreateBuilderWith(ValidConfiguration);
+        builder.AddConfiguredCorsPolicy();
+        using var app = builder.Build();
+
+        // Act & Assert
+        Assert.Same(app, app.UseConfiguredCorsPolicy());
+    }
+
+    [Fact]
+    public void UseConfiguredCorsPolicy_ShouldThrowInvalidOperationException_WhenAddWasNotCalled()
+    {
+        // Arrange
+        // конфигурация валидна, но парный Add* не вызван
+        var builder = CreateBuilderWith(ValidConfiguration);
+        using var app = builder.Build();
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => app.UseConfiguredCorsPolicy());
+    }
+
+    private static WebApplicationBuilder CreateBuilderWith(Dictionary<string, string?> configuration)
+    {
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.Configuration.AddInMemoryCollection(configuration);
+
+        return builder;
+    }
+}

--- a/tests/AndreyAkaSkif.ServiceDefaults.Tests/ConfiguredOpenApiViaSwaggerConfigureExtensionsTests.cs
+++ b/tests/AndreyAkaSkif.ServiceDefaults.Tests/ConfiguredOpenApiViaSwaggerConfigureExtensionsTests.cs
@@ -1,0 +1,101 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace AndreyAkaSkif.ServiceDefaults.Tests;
+
+public class ConfiguredOpenApiViaSwaggerConfigureExtensionsTests
+{
+    private static readonly Dictionary<string, string?> ValidConfiguration = new()
+    {
+        ["SwaggerAppSettings:Title"] = "Title",
+        ["SwaggerAppSettings:Description"] = "Description",
+        ["SwaggerAppSettings:ApiVersion"] = "1.0",
+        ["SwaggerAppSettings:Servers:0"] = "http://localhost:5001",
+    };
+
+    [Fact]
+    public void AddConfiguredOpenApiViaSwagger_ShouldRegisterValidatedSettings_WhenConfigurationIsValid()
+    {
+        // Arrange
+        var builder = CreateBuilderWith(ValidConfiguration);
+
+        // Act
+        builder.AddConfiguredOpenApiViaSwagger();
+        using var app = builder.Build();
+
+        // Assert
+        var settings = app.Services.GetRequiredService<SwaggerAppSettings>();
+        Assert.Equal("Title", settings.Title);
+        Assert.Equal("1.0", settings.ApiVersion);
+        Assert.Equal(["http://localhost:5001"], settings.Servers);
+    }
+
+    [Fact]
+    public void AddConfiguredOpenApiViaSwagger_ShouldThrowArgumentException_WhenConfigurationIsInvalid()
+    {
+        // Arrange
+        var builder = CreateBuilderWith(new Dictionary<string, string?>
+        {
+            ["SwaggerAppSettings:Title"] = "Title",
+        });
+
+        // Act & Assert
+        // валидация выполняется в момент регистрации, а не при разрешении сервиса
+        Assert.Throws<ArgumentException>(() => builder.AddConfiguredOpenApiViaSwagger());
+    }
+
+    [Fact]
+    public void UseConfiguredOpenApiViaSwagger_ShouldNotThrow_WhenAddWasCalled()
+    {
+        // Arrange
+        var builder = CreateBuilderWith(ValidConfiguration, Environments.Development);
+        builder.AddConfiguredOpenApiViaSwagger();
+        using var app = builder.Build();
+
+        // Act & Assert
+        Assert.Same(app, app.UseConfiguredOpenApiViaSwagger());
+    }
+
+    [Fact]
+    public void UseConfiguredOpenApiViaSwagger_ShouldThrowInvalidOperationException_WhenAddWasNotCalled()
+    {
+        // Arrange
+        // конфигурация валидна, но парный Add* не вызван
+        var builder = CreateBuilderWith(ValidConfiguration, Environments.Development);
+        using var app = builder.Build();
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => app.UseConfiguredOpenApiViaSwagger());
+    }
+
+    [Fact]
+    public void UseConfiguredOpenApiViaSwagger_ShouldNotThrow_WhenEnvironmentIsNotDevelopment()
+    {
+        // Arrange
+        // вне development метод не делает ничего и не требует настроек
+        var builder = CreateBuilderWith(ValidConfiguration);
+        using var app = builder.Build();
+
+        // Act & Assert
+        Assert.Same(app, app.UseConfiguredOpenApiViaSwagger());
+    }
+
+    private static WebApplicationBuilder CreateBuilderWith(
+        Dictionary<string, string?> configuration,
+        string? environmentName = null)
+    {
+        environmentName ??= Environments.Production;
+
+        var builder = WebApplication.CreateSlimBuilder(
+            new WebApplicationOptions { EnvironmentName = environmentName });
+        builder.Configuration.AddInMemoryCollection(configuration);
+
+        // SwaggerGen требует ApiExplorer; в development среде хост проверяет
+        // граф зависимостей при Build(), поэтому регистрируем его как в реальном приложении
+        builder.Services.AddEndpointsApiExplorer();
+
+        return builder;
+    }
+}

--- a/tests/AndreyAkaSkif.ServiceDefaults.Tests/GlobalUsings.cs
+++ b/tests/AndreyAkaSkif.ServiceDefaults.Tests/GlobalUsings.cs
@@ -1,5 +1,7 @@
+global using AndreyAkaSkif.ServiceDefaults.Cors;
 global using AndreyAkaSkif.ServiceDefaults.Routing;
 global using AndreyAkaSkif.ServiceDefaults.Settings;
+global using AndreyAkaSkif.ServiceDefaults.Swagger;
 global using System;
 global using System.Collections.Generic;
 global using Xunit;


### PR DESCRIPTION
AddConfiguredCorsPolicy и AddConfiguredOpenApiViaSwagger регистрируют валидированный объект настроек в DI; парные Use* берут его оттуда, а не биндят секцию конфигурации во второй раз. Пропущенный Add* теперь даёт InvalidOperationException сразу, а не невнятное падение позже.

Из XML-доки Swagger убран абзац про необходимость держать секцию в appsettings.json: конфигурация больше не читается на этапе Use*.

Тесты на оба Add/Use: для этого тест-проект получил ссылку на пакет Swagger, а тот — InternalsVisibleTo.

Closes #53