### PR TITLE
build: лицензия-выражение, iconUrl и ссылка на issues

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,11 +27,15 @@
     <Authors>andrey-aka-skif</Authors>
     <Company>AndreyAkaSkif</Company>
     <Copyright>© $([System.DateTime]::Now.Year) @andrey-aka-skif</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
+    <!-- PackageIconUrl помечен deprecated, но VS показывает PackageIcon только для
+         folder-based источников; для http-фидов иконка берётся из iconUrl. NU5048
+         возникает только когда задан один лишь PackageIconUrl, без PackageIcon -->
+    <PackageIconUrl>https://raw.githubusercontent.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/master/logo/logo.png</PackageIconUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AndreyAkaSkif.ServiceDefaults.OpenApi/README.md
+++ b/src/AndreyAkaSkif.ServiceDefaults.OpenApi/README.md
@@ -25,4 +25,7 @@ app.Run();
 
 ## Документация
 Подробности и примеры:
-https://github.com/andrey-aka-skif/ServiceDefaults
+https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults
+
+## Сообщить о проблеме
+https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/issues

--- a/src/AndreyAkaSkif.ServiceDefaults.PostgreSQL/README.md
+++ b/src/AndreyAkaSkif.ServiceDefaults.PostgreSQL/README.md
@@ -24,4 +24,7 @@ app.Run();
 
 ## Документация
 Подробности и примеры:
-https://github.com/andrey-aka-skif/ServiceDefaults
+https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults
+
+## Сообщить о проблеме
+https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/issues

--- a/src/AndreyAkaSkif.ServiceDefaults.Serilog/README.md
+++ b/src/AndreyAkaSkif.ServiceDefaults.Serilog/README.md
@@ -85,4 +85,7 @@ builder.Logging.AddConsole();
 
 ## Документация
 Подробности и примеры:
-https://github.com/andrey-aka-skif/ServiceDefaults
+https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults
+
+## Сообщить о проблеме
+https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/issues

--- a/src/AndreyAkaSkif.ServiceDefaults.Swagger/README.md
+++ b/src/AndreyAkaSkif.ServiceDefaults.Swagger/README.md
@@ -102,3 +102,6 @@ app.Run();
 ## Документация пакета
 Полное описание пакета и другие примеры:
 https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults
+
+## Сообщить о проблеме
+https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/issues

--- a/src/AndreyAkaSkif.ServiceDefaults/README.md
+++ b/src/AndreyAkaSkif.ServiceDefaults/README.md
@@ -96,3 +96,6 @@ app.MapHealthChecks("/ready");                          // /ready — завис
 ## Документация пакета
 Полное описание пакета и другие примеры:
 https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults
+
+## Сообщить о проблеме
+https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/issues


### PR DESCRIPTION
PackageLicenseFile заменён на PackageLicenseExpression: в nuspec теперь <license type="expression">MIT</license> и licenseUrl на licenses.nuget.org. Файл LICENSE остаётся в корне пакета как обычный None.

Добавлен PackageIconUrl рядом с PackageIcon: VS показывает PackageIcon только для folder-based источников, для http-фидов иконка берётся из iconUrl.

В README пакетов добавлен раздел «Сообщить о проблеме» — аналога bugs.url в nuspec нет. Заодно исправлен несуществующий URL репозитория в README OpenApi, PostgreSQL и Serilog.

Closes #70