### PR TITLE
feat: добавлены ограничения маршрута для перечислений

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - политик CORS — настраиваемой через конфигурацию и разрешительной,
 - обработки ошибок через `ProblemDetails`,
 - базового пути API (PathBase),
+- ограничений параметров маршрута, включая перечисление как сегмент пути,
 - конечной точки проверки жизнеспособности (`/health`),
 - валидируемых объектов настроек, проверяемых до старта приложения,
 - спецификации OpenAPI — без UI и через Swagger UI,
@@ -25,7 +26,7 @@
 
 | Пакет | Назначение | README |
 | --- | --- | --- |
-| `AndreyAkaSkif.ServiceDefaults` | CORS, обработка ошибок, PathBase, Health Checks, валидируемые настройки | [README](./src/AndreyAkaSkif.ServiceDefaults/README.md) |
+| `AndreyAkaSkif.ServiceDefaults` | CORS, обработка ошибок, PathBase, ограничения маршрутов, Health Checks, валидируемые настройки | [README](./src/AndreyAkaSkif.ServiceDefaults/README.md) |
 | `AndreyAkaSkif.ServiceDefaults.OpenApi` | Спецификация OpenAPI средствами ASP.NET, без UI | [README](./src/AndreyAkaSkif.ServiceDefaults.OpenApi/README.md) |
 | `AndreyAkaSkif.ServiceDefaults.Swagger` | Спецификация OpenAPI и Swagger UI | [README](./src/AndreyAkaSkif.ServiceDefaults.Swagger/README.md) |
 | `AndreyAkaSkif.ServiceDefaults.PostgreSQL` | Простой контекст PostgreSQL на EF Core | [README](./src/AndreyAkaSkif.ServiceDefaults.PostgreSQL/README.md) |
@@ -52,7 +53,6 @@
 ## 🚧 В планах
 
 - [конфигурация http-клиентов](https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/issues/6),
-- [пользовательские Constraints](https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/issues/29),
 - [документация DocFX](https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/issues/22).
 
 ---

--- a/samples/README.md
+++ b/samples/README.md
@@ -29,6 +29,7 @@ dotnet run --project samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api
 | `/api/health` | Тот же обработчик через базовый путь из `PathBaseAppSettings` (`UseConfiguredPathBase`) |
 | `/demo/greeting` | Настройки `DemoAppSettings`, провалидированные до `Build()` и взятые из DI |
 | `/demo/echo?message=hi` | Обычный маршрут minimal API |
+| `/demo/channel/CurrentA` | Перечисление как сегмент пути (`AddEnumRouteConstraint<DemoChannel>`). `currenta` и `0` тоже работают и приводятся к `CurrentA`, `999` и `unknown` дают 404 |
 | `/demo/boom` | `ProblemDetails` от `AddExtendedErrorHandling`: в Development с полем `exception` |
 
 Логи пишет Serilog (`AddConfiguredLoggingViaSerilog`), конфигурация — секция `Serilog`.

--- a/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Endpoints/DemoChannel.cs
+++ b/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Endpoints/DemoChannel.cs
@@ -1,0 +1,22 @@
+namespace AndreyAkaSkif.ServiceDefaults.Samples.Api.Endpoints;
+
+/// <summary>
+/// Демонстрационный тип канала: используется как сегмент пути
+/// </summary>
+internal enum DemoChannel
+{
+    /// <summary>
+    /// Ток по фазе A
+    /// </summary>
+    CurrentA,
+
+    /// <summary>
+    /// Напряжение по фазе A
+    /// </summary>
+    VoltageA,
+
+    /// <summary>
+    /// Крутящий момент
+    /// </summary>
+    Torque,
+}

--- a/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Endpoints/DemoEndpoints.cs
+++ b/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Endpoints/DemoEndpoints.cs
@@ -24,6 +24,12 @@ internal static class DemoEndpoints
             .WithName("GetEcho")
             .WithSummary("Эхо query-параметра");
 
+        // Ограничение "demoChannel" зарегистрировал AddEnumRouteConstraint<DemoChannel>().
+        // Значение вне перечисления сюда не доходит: маршрут не выбирается, ответ 404
+        demo.MapGet("/channel/{channel:demoChannel}", (DemoChannel channel) => Results.Ok(new { channel }))
+            .WithName("GetChannel")
+            .WithSummary("Перечисление как сегмент пути: /demo/channel/CurrentA");
+
         // Исключение перехватывает middleware из UseErrorHandling() и возвращает
         // ProblemDetails. В Development к нему добавляется поле "exception" —
         // это делает AddExtendedErrorHandling()

--- a/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Program.cs
+++ b/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Program.cs
@@ -30,6 +30,11 @@ builder.AddConfiguredCorsPolicy();
 // Конечная точка /health и её отображение в Swagger UI
 builder.AddHealthCheckEndpointWithSwagger();
 
+// Перечисление как сегмент пути: ограничение доступно в шаблоне как "demoChannel" —
+// имя по умолчанию от имени типа. Заодно включается сериализация перечислений
+// именами, иначе в теле ответа и в спецификации они выглядели бы как 0, 1, 2
+builder.AddEnumRouteConstraint<DemoChannel>();
+
 // --- OpenApi без Swagger -----------------------------------------------------
 // Альтернатива паре AddConfiguredOpenApiViaSwagger/UseConfiguredOpenApiViaSwagger:
 // встроенная в ASP.NET генерация спецификации без Swagger UI.

--- a/src/AndreyAkaSkif.ServiceDefaults/README.md
+++ b/src/AndreyAkaSkif.ServiceDefaults/README.md
@@ -15,6 +15,9 @@ dotnet add package AndreyAkaSkif.ServiceDefaults
     - политика CORS, настроенная через конфигурацию (`AddConfiguredCorsPolicy()` / `UseConfiguredCorsPolicy()`)
     - разрешительная политика CORS «всё со всех источников» (`AddPermissiveCorsPolicy()` / `UsePermissiveCorsPolicy()`)
     - саброутинг — базовый путь из конфигурации (`UseConfiguredPathBase()`)
+    - перечисление как сегмент пути со строковой сериализацией (`AddEnumRouteConstraint<T>()`);
+      отдельно доступны сериализация перечислений именами (`AddStringEnumJsonSerialization()`)
+      и регистрация собственного ограничения маршрута (`AddRouteConstraint<T>(name)`)
     - обработка ошибок с использованием ProblemDetails — стандартная (`AddDefaultErrorHandling()`)
       и расширенная (`AddExtendedErrorHandling()`), подключение в конвейер — `UseErrorHandling()`
     - конечная точка проверки жизнеспособности приложения для оркестратора
@@ -65,6 +68,89 @@ RFC 7807 в любой среде.
 у стандартного варианта.
 
 Оба метода требуют вызова `UseErrorHandling()` — см. раздел «⚠️ Важно».
+
+## Перечисление как сегмент пути
+Перечисление в маршруте по умолчанию неинформативно: спецификация OpenAPI объявляет его
+целочисленным, Swagger UI предлагает ввести `0`, `1`, `2`, и в адресе оказывается
+`/channel/2` вместо `/channel/Torque`. Решается одним вызовом:
+
+```csharp
+builder.AddEnumRouteConstraint<ChannelType>();
+
+app.MapGet("channel/{channel:channelType}", (ChannelType channel) => channel);
+```
+
+Имя ограничения по умолчанию — имя типа со строчной первой буквы, для `ChannelType` это
+`channelType`. Другое имя задаётся параметром: `AddEnumRouteConstraint<ChannelType>("channel")`.
+
+Поведение:
+
+| Запрос | Результат |
+| --- | --- |
+| `/channel/Torque` | 200 |
+| `/channel/torque` | 200 — сопоставление регистронезависимо |
+| `/channel/2` | 200 — числовые значения допустимы |
+| `/channel/999` | 404 — значения нет в перечислении |
+| `/channel/unknown` | 404 |
+
+Значение приводится к каноническому имени элемента до привязки аргумента. Это важно:
+привязка в минимальных API регистрозависима, поэтому без приведения `/channel/torque`
+совпал бы с маршрутом и упал с 400 при разборе аргумента. Некорректное значение даёт 404
+от маршрутизации, а не 400 от привязки.
+
+Работает одинаково и для минимальных API, и для контроллеров: `ConstraintMap` живёт
+в `RouteOptions`, который читает общий для обоих стилей резолвер ограничений.
+
+```csharp
+[HttpGet("channel/{channel:channelType}")]
+public IActionResult Get(ChannelType channel) => Ok(channel);
+```
+
+Приведение к каноническому имени для контроллеров избыточно — привязка модели там идёт
+через `EnumConverter` и уже регистронезависима, — но поведение от этого не меняется.
+
+Заодно метод включает сериализацию перечислений именами — иначе тела ответов и
+спецификация остались бы с числами и задача решилась бы наполовину. Настраиваются оба
+набора параметров: `Microsoft.AspNetCore.Http.Json` для минимальных API и
+`Microsoft.AspNetCore.Mvc.Json` для контроллеров. Второй нужен ещё и потому, что генератор
+спецификации Swashbuckle читает именно его. Приложению без контроллеров это не вредит.
+
+Если перечисления встречаются только в телах ответов и ограничение маршрута не нужно,
+та же настройка доступна отдельно:
+
+```csharp
+builder.AddStringEnumJsonSerialization();
+```
+
+Вызов идемпотентен, поэтому регистрация нескольких перечислений его не дублирует.
+
+### Собственные ограничения
+`AddEnumRouteConstraint<T>()` построен поверх метода общего назначения, которым
+регистрируется любая реализация `IRouteConstraint`. Сам по себе он задачу не решает —
+он нужен, когда ограничение написано своё:
+
+```csharp
+public sealed class EvenNumberRouteConstraint : IRouteConstraint
+{
+    public bool Match(
+        HttpContext? httpContext,
+        IRouter? route,
+        string routeKey,
+        RouteValueDictionary values,
+        RouteDirection routeDirection)
+        => values.TryGetValue(routeKey, out var value)
+           && int.TryParse(value?.ToString(), out var number)
+           && number % 2 == 0;
+}
+
+builder.AddRouteConstraint<EvenNumberRouteConstraint>("even");
+
+app.MapGet("items/{id:even}", (int id) => id);
+```
+
+Повторная регистрация того же типа под тем же именем допустима и ничего не меняет.
+Регистрация другого типа под занятым именем — `InvalidOperationException`. Встроенные
+ограничения (`int`, `guid`, `alpha` и прочие) остаются доступны.
 
 ## Секции конфигурации
 Имя секции всегда совпадает с именем типа настроек: привязка выполняется через

--- a/src/AndreyAkaSkif.ServiceDefaults/Routing/EnumRouteConstraint.cs
+++ b/src/AndreyAkaSkif.ServiceDefaults/Routing/EnumRouteConstraint.cs
@@ -1,0 +1,63 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace AndreyAkaSkif.ServiceDefaults.Routing;
+
+/// <summary>
+/// Ограничение параметра маршрута значениями перечисления <typeparamref name="TEnum"/>
+/// </summary>
+/// <typeparam name="TEnum">Тип перечисления, допустимый в сегменте пути</typeparam>
+/// <remarks>
+/// <para>
+/// Регистрируется через
+/// <see cref="RouteConstraintExtensions.AddEnumRouteConstraint{TEnum}(Microsoft.Extensions.Hosting.IHostApplicationBuilder, string?)"/>
+/// и применяется в шаблоне маршрута: <c>"channel/{channel:channelType}"</c>.
+/// </para>
+/// <para>
+/// Сопоставление регистронезависимо, числовые значения также допустимы. Значение,
+/// не соответствующее ни одному элементу перечисления, маршрут не выбирает — клиент
+/// получает 404, а не 400 при привязке аргумента.
+/// </para>
+/// </remarks>
+public sealed class EnumRouteConstraint<TEnum> : IRouteConstraint
+    where TEnum : struct, Enum
+{
+    /// <summary>
+    /// Проверяет значение параметра маршрута и приводит его к каноническому виду
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/>, если значение соответствует элементу <typeparamref name="TEnum"/>
+    /// </returns>
+    public bool Match(
+        HttpContext? httpContext,
+        IRouter? route,
+        string routeKey,
+        RouteValueDictionary values,
+        RouteDirection routeDirection)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+
+        if (!values.TryGetValue(routeKey, out var rawValue))
+            return false;
+
+        var text = Convert.ToString(rawValue, CultureInfo.InvariantCulture);
+
+        if (string.IsNullOrEmpty(text))
+            return false;
+
+        // Enum.TryParse принимает и число вне диапазона: "999" разберётся в (TEnum)999,
+        // поэтому результат дополнительно проверяется через IsDefined
+        if (!Enum.TryParse<TEnum>(text, ignoreCase: true, out var parsed) || !Enum.IsDefined(parsed))
+            return false;
+
+        // Привязка аргументов в минимальных API регистрозависима: она использует
+        // Enum.TryParse<T>(string, out T) без ignoreCase. Без приведения к каноническому
+        // имени "/channel/currenta" прошёл бы маршрутизацию и упал бы с 400.
+        // При генерации URL значение принадлежит вызывающему коду и не изменяется.
+        if (routeDirection == RouteDirection.IncomingRequest)
+            values[routeKey] = parsed.ToString();
+
+        return true;
+    }
+}

--- a/src/AndreyAkaSkif.ServiceDefaults/Routing/RouteConstraintExtensions.cs
+++ b/src/AndreyAkaSkif.ServiceDefaults/Routing/RouteConstraintExtensions.cs
@@ -1,0 +1,145 @@
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace AndreyAkaSkif.ServiceDefaults.Routing;
+
+/// <summary>
+/// Методы расширения для регистрации ограничений параметров маршрута в DI-контейнере
+/// </summary>
+public static class RouteConstraintExtensions
+{
+    /// <summary>
+    /// Зарегистрировать произвольное ограничение параметра маршрута под указанным именем
+    /// </summary>
+    /// <typeparam name="TConstraint">Тип ограничения</typeparam>
+    /// <param name="builder">Строитель приложения</param>
+    /// <param name="name">Имя, под которым ограничение доступно в шаблоне маршрута</param>
+    /// <remarks>
+    /// <para>
+    /// Метод общего назначения: он не решает конкретную задачу, а служит основой для
+    /// построения ограничений. Для перечислений готовое решение уже есть —
+    /// <see cref="AddEnumRouteConstraint{TEnum}(IHostApplicationBuilder, string?)"/>,
+    /// который построен поверх этого метода. Напрямую метод нужен, когда написана
+    /// собственная реализация <c>IRouteConstraint</c>.
+    /// </para>
+    /// <para>
+    /// Пример собственного ограничения — только чётные числа:
+    /// <code>
+    /// public sealed class EvenNumberRouteConstraint : IRouteConstraint
+    /// {
+    ///     public bool Match(
+    ///         HttpContext? httpContext,
+    ///         IRouter? route,
+    ///         string routeKey,
+    ///         RouteValueDictionary values,
+    ///         RouteDirection routeDirection)
+    ///         => values.TryGetValue(routeKey, out var value)
+    ///            &amp;&amp; int.TryParse(value?.ToString(), out var number)
+    ///            &amp;&amp; number % 2 == 0;
+    /// }
+    ///
+    /// builder.AddRouteConstraint&lt;EvenNumberRouteConstraint&gt;("even");
+    ///
+    /// app.MapGet("items/{id:even}", (int id) => id);
+    /// </code>
+    /// </para>
+    /// <para>
+    /// Имя используется в шаблоне после двоеточия: при регистрации под именем
+    /// <c>"channelType"</c> шаблон выглядит как <c>"channel/{channel:channelType}"</c>.
+    /// </para>
+    /// <para>
+    /// Повторная регистрация того же типа под тем же именем допустима и ничего не меняет.
+    /// Регистрация другого типа под занятым именем считается ошибкой: иначе конфликт
+    /// проявился бы при разрешении <c>RouteOptions</c>, вдалеке от места регистрации.
+    /// </para>
+    /// </remarks>
+    /// <returns>Тот же экземпляр <paramref name="builder"/> для поддержки цепочки вызовов</returns>
+    /// <exception cref="ArgumentException">если <paramref name="name"/> пуст</exception>
+    /// <exception cref="InvalidOperationException">
+    /// если под этим именем уже зарегистрировано ограничение другого типа
+    /// </exception>
+    public static IHostApplicationBuilder AddRouteConstraint<TConstraint>(
+        this IHostApplicationBuilder builder,
+        string name)
+        where TConstraint : IRouteConstraint
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Не задано имя ограничения маршрута", nameof(name));
+
+        builder.Services.Configure<RouteOptions>(options =>
+        {
+            if (options.ConstraintMap.TryGetValue(name, out var registered))
+            {
+                if (registered == typeof(TConstraint))
+                    return;
+
+                throw new InvalidOperationException(
+                    $"Имя ограничения маршрута \"{name}\" уже занято типом {registered.Name}. " +
+                    $"Задайте другое имя для {typeof(TConstraint).Name}.");
+            }
+
+            options.ConstraintMap[name] = typeof(TConstraint);
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Зарегистрировать ограничение параметра маршрута значениями перечисления
+    /// </summary>
+    /// <typeparam name="TEnum">Тип перечисления, допустимый в сегменте пути</typeparam>
+    /// <param name="builder">Строитель приложения</param>
+    /// <param name="name">
+    /// Имя ограничения в шаблоне маршрута. По умолчанию — имя типа перечисления
+    /// со строчной первой буквой: для <c>ChannelType</c> это <c>"channelType"</c>
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// Пример использования:
+    /// <code>
+    /// builder.AddEnumRouteConstraint&lt;ChannelType&gt;();
+    ///
+    /// app.MapGet("channel/{channel:channelType}", (ChannelType channel) => channel);
+    /// </code>
+    /// </para>
+    /// <para>
+    /// Сопоставление регистронезависимо, числовые значения также допустимы, а значение
+    /// приводится к каноническому имени элемента перечисления до привязки аргумента.
+    /// Значение вне перечисления маршрут не выбирает — ответ 404.
+    /// </para>
+    /// <para>
+    /// Работает одинаково для минимальных API и для контроллеров: <c>ConstraintMap</c>
+    /// принадлежит <c>RouteOptions</c>, который читает общий для обоих стилей резолвер
+    /// ограничений.
+    /// </para>
+    /// <para>
+    /// Дополнительно включается сериализация перечислений именами
+    /// (<see cref="StringEnumJsonExtensions.AddStringEnumJsonSerialization(IHostApplicationBuilder)"/>):
+    /// без неё спецификация OpenApi объявляла бы перечисление целочисленным, и задача
+    /// читаемости решалась бы наполовину. Настройка идемпотентна, поэтому регистрация
+    /// нескольких перечислений не приводит к её дублированию.
+    /// </para>
+    /// </remarks>
+    /// <returns>Тот же экземпляр <paramref name="builder"/> для поддержки цепочки вызовов</returns>
+    /// <exception cref="InvalidOperationException">
+    /// если под этим именем уже зарегистрировано ограничение другого типа
+    /// </exception>
+    public static IHostApplicationBuilder AddEnumRouteConstraint<TEnum>(
+        this IHostApplicationBuilder builder,
+        string? name = null)
+        where TEnum : struct, Enum
+        => builder
+            .AddRouteConstraint<EnumRouteConstraint<TEnum>>(name ?? DefaultNameFor<TEnum>())
+            .AddStringEnumJsonSerialization();
+
+    private static string DefaultNameFor<TEnum>()
+        where TEnum : struct, Enum
+    {
+        var typeName = typeof(TEnum).Name;
+
+        return char.ToLowerInvariant(typeName[0]) + typeName[1..];
+    }
+}

--- a/src/AndreyAkaSkif.ServiceDefaults/Routing/StringEnumJsonExtensions.cs
+++ b/src/AndreyAkaSkif.ServiceDefaults/Routing/StringEnumJsonExtensions.cs
@@ -1,0 +1,65 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using MvcJsonOptions = Microsoft.AspNetCore.Mvc.JsonOptions;
+
+namespace AndreyAkaSkif.ServiceDefaults.Routing;
+
+/// <summary>
+/// Методы расширения для сериализации перечислений именами элементов
+/// </summary>
+public static class StringEnumJsonExtensions
+{
+    /// <summary>
+    /// Сериализовать перечисления именами элементов вместо числовых значений
+    /// </summary>
+    /// <param name="builder">Строитель приложения</param>
+    /// <remarks>
+    /// <para>
+    /// По умолчанию <c>JsonSerializerDefaults.Web</c> не подключает
+    /// <see cref="JsonStringEnumConverter"/>, поэтому перечисления и в телах ответов,
+    /// и в спецификации OpenApi выглядят числами. Swagger UI в таком случае предлагает
+    /// ввести <c>0</c>, <c>1</c>, <c>2</c> вместо осмысленных имён.
+    /// </para>
+    /// <para>
+    /// Вызывать явно нужно только тогда, когда перечисления встречаются лишь в телах
+    /// ответов. Для перечисления в сегменте пути достаточно
+    /// <see cref="RouteConstraintExtensions.AddEnumRouteConstraint{TEnum}(IHostApplicationBuilder, string?)"/>:
+    /// он выполняет эту настройку сам.
+    /// </para>
+    /// <para>
+    /// Настраиваются оба набора параметров сериализации: <c>Microsoft.AspNetCore.Http.Json</c>
+    /// для минимальных API и <c>Microsoft.AspNetCore.Mvc.Json</c> для контроллеров.
+    /// Второй нужен ещё и потому, что генератор спецификации Swashbuckle читает именно его:
+    /// без этого тела ответов содержали бы имена, а спецификация по-прежнему объявляла бы
+    /// перечисление целочисленным. Приложению без контроллеров вторая настройка не вредит.
+    /// </para>
+    /// <para>
+    /// Повторный вызов ничего не меняет: конвертер добавляется, только если его ещё нет.
+    /// </para>
+    /// </remarks>
+    /// <returns>Тот же экземпляр <paramref name="builder"/> для поддержки цепочки вызовов</returns>
+    public static IHostApplicationBuilder AddStringEnumJsonSerialization(this IHostApplicationBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Services.ConfigureHttpJsonOptions(options =>
+            AddStringEnumConverter(options.SerializerOptions));
+
+        builder.Services.Configure<MvcJsonOptions>(options =>
+            AddStringEnumConverter(options.JsonSerializerOptions));
+
+        return builder;
+    }
+
+    private static void AddStringEnumConverter(JsonSerializerOptions options)
+    {
+        // метод вызывается из AddEnumRouteConstraint для каждого перечисления,
+        // поэтому повторный вызов не должен наполнять список копиями конвертера
+        if (options.Converters.Any(converter => converter is JsonStringEnumConverter))
+            return;
+
+        options.Converters.Add(new JsonStringEnumConverter());
+    }
+}

--- a/tests/AndreyAkaSkif.ServiceDefaults.Tests/EnumRouteConstraintTests.cs
+++ b/tests/AndreyAkaSkif.ServiceDefaults.Tests/EnumRouteConstraintTests.cs
@@ -1,0 +1,142 @@
+using Microsoft.AspNetCore.Routing;
+
+namespace AndreyAkaSkif.ServiceDefaults.Tests;
+
+public class EnumRouteConstraintTests
+{
+    [Theory]
+    [InlineData("CurrentA")]
+    // сопоставление регистронезависимо
+    [InlineData("currenta")]
+    [InlineData("CURRENTA")]
+    // числовые значения в диапазоне перечисления допустимы
+    [InlineData("0")]
+    [InlineData("2")]
+    public void Match_ShouldReturnTrue_WhenValueBelongsToEnum(string value)
+    {
+        // Arrange
+        var constraint = new EnumRouteConstraint<TestChannel>();
+        var values = new RouteValueDictionary { ["channel"] = value };
+
+        // Act
+        var matched = Match(constraint, values);
+
+        // Assert
+        Assert.True(matched);
+    }
+
+    [Theory]
+    [InlineData("unknown")]
+    // Enum.TryParse разобрал бы это в (TestChannel)999 — отсекается через Enum.IsDefined
+    [InlineData("999")]
+    [InlineData("-1")]
+    [InlineData("")]
+    public void Match_ShouldReturnFalse_WhenValueIsOutsideEnum(string value)
+    {
+        // Arrange
+        var constraint = new EnumRouteConstraint<TestChannel>();
+        var values = new RouteValueDictionary { ["channel"] = value };
+
+        // Act
+        var matched = Match(constraint, values);
+
+        // Assert
+        Assert.False(matched);
+    }
+
+    [Fact]
+    public void Match_ShouldReturnFalse_WhenRouteKeyIsMissing()
+    {
+        // Arrange
+        var constraint = new EnumRouteConstraint<TestChannel>();
+        var values = new RouteValueDictionary();
+
+        // Act
+        var matched = Match(constraint, values);
+
+        // Assert
+        Assert.False(matched);
+    }
+
+    [Fact]
+    public void Match_ShouldReturnFalse_WhenValueIsNull()
+    {
+        // Arrange
+        var constraint = new EnumRouteConstraint<TestChannel>();
+        var values = new RouteValueDictionary { ["channel"] = null };
+
+        // Act
+        var matched = Match(constraint, values);
+
+        // Assert
+        Assert.False(matched);
+    }
+
+    [Theory]
+    [InlineData("currenta", "CurrentA")]
+    [InlineData("CURRENTA", "CurrentA")]
+    [InlineData("2", "Torque")]
+    public void Match_ShouldNormalizeValue_WhenRequestIsIncoming(string value, string expected)
+    {
+        // Arrange
+        // привязка аргументов в минимальных API регистрозависима, поэтому значение
+        // приводится к каноническому имени — иначе маршрут совпал бы, а привязка упала
+        var constraint = new EnumRouteConstraint<TestChannel>();
+        var values = new RouteValueDictionary { ["channel"] = value };
+
+        // Act
+        Match(constraint, values);
+
+        // Assert
+        Assert.Equal(expected, values["channel"]);
+    }
+
+    [Fact]
+    public void Match_ShouldNotChangeValue_WhenDirectionIsUrlGeneration()
+    {
+        // Arrange
+        // при генерации URL значение принадлежит вызывающему коду
+        var constraint = new EnumRouteConstraint<TestChannel>();
+        var values = new RouteValueDictionary { ["channel"] = "currenta" };
+
+        // Act
+        var matched = Match(constraint, values, RouteDirection.UrlGeneration);
+
+        // Assert
+        Assert.True(matched);
+        Assert.Equal("currenta", values["channel"]);
+    }
+
+    [Fact]
+    public void Match_ShouldAcceptEnumInstance_WhenValueIsNotString()
+    {
+        // Arrange
+        // при генерации URL в словарь попадает само значение перечисления, а не строка
+        var constraint = new EnumRouteConstraint<TestChannel>();
+        var values = new RouteValueDictionary { ["channel"] = TestChannel.Torque };
+
+        // Act
+        var matched = Match(constraint, values, RouteDirection.UrlGeneration);
+
+        // Assert
+        Assert.True(matched);
+    }
+
+    private static bool Match(
+        EnumRouteConstraint<TestChannel> constraint,
+        RouteValueDictionary values,
+        RouteDirection direction = RouteDirection.IncomingRequest)
+        => constraint.Match(
+            httpContext: null,
+            route: null,
+            routeKey: "channel",
+            values: values,
+            routeDirection: direction);
+
+    private enum TestChannel
+    {
+        CurrentA,
+        CurrentB,
+        Torque,
+    }
+}

--- a/tests/AndreyAkaSkif.ServiceDefaults.Tests/RouteConstraintExtensionsTests.cs
+++ b/tests/AndreyAkaSkif.ServiceDefaults.Tests/RouteConstraintExtensionsTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Constraints;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace AndreyAkaSkif.ServiceDefaults.Tests;
+
+public class RouteConstraintExtensionsTests
+{
+    [Fact]
+    public void AddEnumRouteConstraint_ShouldUseCamelCasedTypeName_WhenNameIsNotSpecified()
+    {
+        // Arrange
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+
+        // Act
+        builder.AddEnumRouteConstraint<TestChannel>();
+
+        // Assert
+        var constraintMap = ResolveConstraintMap(builder);
+        Assert.Equal(typeof(EnumRouteConstraint<TestChannel>), constraintMap["testChannel"]);
+    }
+
+    [Fact]
+    public void AddEnumRouteConstraint_ShouldUseExplicitName_WhenNameIsSpecified()
+    {
+        // Arrange
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+
+        // Act
+        builder.AddEnumRouteConstraint<TestChannel>("channel");
+
+        // Assert
+        var constraintMap = ResolveConstraintMap(builder);
+        Assert.Equal(typeof(EnumRouteConstraint<TestChannel>), constraintMap["channel"]);
+        Assert.False(constraintMap.ContainsKey("testChannel"));
+    }
+
+    [Fact]
+    public void AddRouteConstraint_ShouldNotThrow_WhenSameTypeIsRegisteredTwice()
+    {
+        // Arrange
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+
+        // Act
+        builder.AddEnumRouteConstraint<TestChannel>("channel");
+        builder.AddEnumRouteConstraint<TestChannel>("channel");
+
+        // Assert
+        var constraintMap = ResolveConstraintMap(builder);
+        Assert.Equal(typeof(EnumRouteConstraint<TestChannel>), constraintMap["channel"]);
+    }
+
+    [Fact]
+    public void AddRouteConstraint_ShouldThrowInvalidOperationException_WhenNameIsTakenByAnotherType()
+    {
+        // Arrange
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.AddEnumRouteConstraint<TestChannel>("channel");
+        builder.AddEnumRouteConstraint<TestUnit>("channel");
+
+        // Act & Assert
+        // делегат Configure выполняется при разрешении RouteOptions, а не при регистрации
+        var exception = Assert.Throws<InvalidOperationException>(() => ResolveConstraintMap(builder));
+        Assert.Contains("channel", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddRouteConstraint_ShouldNotReplaceBuiltInConstraints()
+    {
+        // Arrange
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+
+        // Act
+        builder.AddEnumRouteConstraint<TestChannel>();
+
+        // Assert
+        var constraintMap = ResolveConstraintMap(builder);
+        Assert.Equal(typeof(IntRouteConstraint), constraintMap["int"]);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void AddEnumRouteConstraint_ShouldThrowArgumentException_WhenNameIsBlank(string? name)
+    {
+        // Arrange
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+
+        // Act & Assert
+        // пустое имя отвергается сразу, а не при разрешении RouteOptions:
+        // null означает имя по умолчанию и до этой проверки не доходит
+        var exception = Assert.Throws<ArgumentException>(
+            () => builder.AddRouteConstraint<EnumRouteConstraint<TestChannel>>(name!));
+        Assert.Equal("name", exception.ParamName);
+    }
+
+    private static IDictionary<string, Type> ResolveConstraintMap(HostApplicationBuilder builder)
+    {
+        using var host = builder.Build();
+
+        return host.Services.GetRequiredService<IOptions<RouteOptions>>().Value.ConstraintMap;
+    }
+
+    private enum TestChannel
+    {
+        CurrentA,
+        Torque,
+    }
+
+    private enum TestUnit
+    {
+        Volt,
+        Ampere,
+    }
+}

--- a/tests/AndreyAkaSkif.ServiceDefaults.Tests/StringEnumJsonExtensionsTests.cs
+++ b/tests/AndreyAkaSkif.ServiceDefaults.Tests/StringEnumJsonExtensionsTests.cs
@@ -1,0 +1,104 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using HttpJsonOptions = Microsoft.AspNetCore.Http.Json.JsonOptions;
+using MvcJsonOptions = Microsoft.AspNetCore.Mvc.JsonOptions;
+
+namespace AndreyAkaSkif.ServiceDefaults.Tests;
+
+public class StringEnumJsonExtensionsTests
+{
+    [Fact]
+    public void AddStringEnumJsonSerialization_ShouldConfigureHttpJsonOptions()
+    {
+        // Arrange
+        var builder = WebApplication.CreateSlimBuilder();
+
+        // Act
+        builder.AddStringEnumJsonSerialization();
+        using var app = builder.Build();
+
+        // Assert
+        var options = app.Services.GetRequiredService<IOptions<HttpJsonOptions>>().Value;
+        Assert.Equal("\"Torque\"", Serialize(options.SerializerOptions));
+    }
+
+    [Fact]
+    public void AddStringEnumJsonSerialization_ShouldConfigureMvcJsonOptions()
+    {
+        // Arrange
+        // генератор спецификации Swashbuckle читает именно MVC-параметры: без них тела
+        // ответов содержали бы имена, а спецификация объявляла бы перечисление числовым
+        var builder = WebApplication.CreateSlimBuilder();
+
+        // Act
+        builder.AddStringEnumJsonSerialization();
+        using var app = builder.Build();
+
+        // Assert
+        var options = app.Services.GetRequiredService<IOptions<MvcJsonOptions>>().Value;
+        Assert.Equal("\"Torque\"", Serialize(options.JsonSerializerOptions));
+    }
+
+    [Fact]
+    public void AddStringEnumJsonSerialization_ShouldAddConverterOnce_WhenCalledRepeatedly()
+    {
+        // Arrange
+        // метод вызывается из AddEnumRouteConstraint для каждого перечисления
+        var builder = WebApplication.CreateSlimBuilder();
+
+        // Act
+        builder.AddStringEnumJsonSerialization();
+        builder.AddStringEnumJsonSerialization();
+        builder.AddStringEnumJsonSerialization();
+        using var app = builder.Build();
+
+        // Assert
+        var options = app.Services.GetRequiredService<IOptions<HttpJsonOptions>>().Value;
+        Assert.Single(options.SerializerOptions.Converters, c => c is JsonStringEnumConverter);
+    }
+
+    [Fact]
+    public void AddEnumRouteConstraint_ShouldEnableStringEnumSerialization()
+    {
+        // Arrange
+        // ограничение маршрута без строковой сериализации решало бы задачу наполовину:
+        // спецификация продолжала бы объявлять перечисление целочисленным
+        var builder = WebApplication.CreateSlimBuilder();
+
+        // Act
+        builder.AddEnumRouteConstraint<TestChannel>();
+        using var app = builder.Build();
+
+        // Assert
+        var options = app.Services.GetRequiredService<IOptions<HttpJsonOptions>>().Value;
+        Assert.Equal("\"Torque\"", Serialize(options.SerializerOptions));
+    }
+
+    [Fact]
+    public void HttpJsonOptions_ShouldSerializeEnumAsNumber_WhenExtensionIsNotCalled()
+    {
+        // Arrange
+        var builder = WebApplication.CreateSlimBuilder();
+
+        // Act
+        using var app = builder.Build();
+
+        // Assert
+        // подтверждает исходную задачу: по умолчанию перечисление уезжает числом
+        var options = app.Services.GetRequiredService<IOptions<HttpJsonOptions>>().Value;
+        Assert.Equal("2", Serialize(options.SerializerOptions));
+    }
+
+    private static string Serialize(JsonSerializerOptions options)
+        => JsonSerializer.Serialize(TestChannel.Torque, options);
+
+    private enum TestChannel
+    {
+        CurrentA,
+        VoltageA,
+        Torque,
+    }
+}


### PR DESCRIPTION
Перечисление в сегменте пути было неинформативно: спецификация объявляла его целочисленным, Swagger UI предлагал ввести 0, 1, 2, и в адресе оказывалось /channel/2 вместо /channel/Torque. Встроенного ограничения для перечислений в ASP.NET Core нет, готовые пакеты заброшены со времён ASP.NET Core 2.

AddEnumRouteConstraint<TEnum>(name?) решает задачу одним вызовом: имя ограничения по умолчанию берётся от имени типа, сопоставление регистронезависимо, числовые значения допустимы, значение вне перечисления даёт 404 от маршрутизации, а не 400 от привязки аргумента. Проверено на образце и для минимальных API, и для контроллеров: ConstraintMap принадлежит RouteOptions, который читает общий для обоих стилей резолвер ограничений.

Enum.TryParse принимает и число вне диапазона, разбирая "999" в (TEnum)999, поэтому результат дополнительно проверяется через Enum.IsDefined. Значение приводится к каноническому имени элемента: привязка аргументов в минимальных API использует Enum.TryParse<T> без ignoreCase, поэтому без приведения "/channel/torque" совпал бы с маршрутом и упал бы с 400. Для контроллеров приведение избыточно - там привязка идёт через EnumConverter и уже регистронезависима.

Тот же вызов включает сериализацию перечислений именами - иначе спецификация осталась бы с числами и задача решалась бы наполовину. Настраиваются оба набора параметров, Http.Json и Mvc.Json. Второй нужен не только контроллерам: генератор спецификации Swashbuckle читает именно его, и без этой настройки тела ответов содержали бы имена, а спецификация по-прежнему объявляла бы перечисление целочисленным. Настройка идемпотентна, поэтому регистрация нескольких перечислений её не дублирует. Отдельно доступна как AddStringEnumJsonSerialization() - для случая, когда перечисления встречаются только в телах ответов.

Встроенный AddOpenApi отдаёт имена и без дополнительной настройки, поэтому отображение схемы для каждого перечисления не понадобилось.

Основой служит AddRouteConstraint<TConstraint>(name) - метод общего назначения для собственных реализаций IRouteConstraint, с примером в документации. Повторная регистрация того же типа под тем же именем идемпотентна, регистрация другого типа под занятым именем считается ошибкой: иначе конфликт проявился бы при разрешении RouteOptions, вдалеке от места регистрации.

Closes #29