### PR TITLE
refactor: конфигурация образца вынесена в AppConfiguration

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -28,6 +28,7 @@ dotnet run --project samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api
 | `/health`                     | `MapHealthCheckEndpoint`; в спецификацию точку добавляет `AddHealthCheckEndpointWithSwagger`                                                                |
 | `/api/health`                 | Тот же обработчик через базовый путь из `PathBaseAppSettings` (`UseConfiguredPathBase`)                                                                     |
 | `/demo/greeting`              | Настройки `DemoAppSettings`, провалидированные до `Build()` и взятые из DI                                                                                  |
+| `/demo/greeting/Мир`          | Сервис с собственным объектом-параметром `GreetingServiceArgs` вместо объекта секции                                                                        |
 | `/demo/echo?message=hi`       | Обычный маршрут minimal API                                                                                                                                 |
 | `/demo/channel/CurrentA`      | Перечисление как сегмент пути (`AddEnumRouteConstraint<DemoChannel>`). `currenta` и `0` тоже работают и приводятся к `CurrentA`, `999` и `unknown` дают 404 |
 | `/demo/boom`                  | `ProblemDetails` от `AddExtendedErrorHandling`: в Development с полем `exception`                                                                           |
@@ -37,6 +38,51 @@ dotnet run --project samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api
 файлов. Ради консоли отдельный пакет не нужен — её умеет и встроенный провайдер; Serilog
 подключают, когда логи нужно писать куда-то ещё, см. README пакета.
 Политика CORS берётся из секции `CorsPolicy`.
+
+## Как разложен код
+
+```
+Program.cs              подключение пакетов библиотеки и конвейер
+AppConfiguration/       конфигурация, специфичная для приложения
+AppSettings/            объекты секций конфигурации
+Endpoints/              конечные точки и типы, которые в них участвуют
+Services/               сервисы приложения и их объекты-параметры
+```
+
+В `AppConfiguration/` лежат четыре метода расширения — по одному на тему, чтобы
+`Program.cs` не рос по мере развития приложения:
+
+| Метод                      | Что регистрирует                                                      |
+| -------------------------- | --------------------------------------------------------------------- |
+| `AddAppSettings()`         | объекты настроек, здесь — `DemoAppSettings`                           |
+| `AddAppDbContexts()`       | контексты EF Core; в образце выключен, требует запущенного PostgreSQL |
+| `AddAppServices()`         | сервисы приложения, здесь — `GreetingService`                         |
+| `AddAppRouteConstraints()` | ограничения параметров маршрута, здесь — `DemoChannel`                |
+
+### Почему объекты настроек лежат в двух разных местах
+
+За словом «настройки» скрываются две роли, и образец показывает обе.
+
+`DemoAppSettings` — **объект секции конфигурации**. Он знает имя секции (оно равно имени
+типа), реализует `IValidatableSettingsObject` и читается из `appsettings.json`. Это тип
+границы приложения, поэтому он лежит в `AppSettings/` и регистрируется через
+`AddServiceArgFromValidatedSettingsObject<T>()`.
+
+`GreetingServiceArgs` — **объект-параметр сервиса**. Про конфигурацию он не знает ничего
+и наследовать `IValidatableSettingsObject` не обязан; он существует ровно затем, чтобы
+в домен не пришлось тащить `IOptions<T>`. Такой тип принадлежит сервису и лежит рядом
+с ним, в `Services/`.
+
+Переход между ролями происходит в composition root — в `AddAppServices()`, где значение
+из `DemoAppSettings` отображается в `GreetingServiceArgs`. Сам сервис остаётся
+независимым от того, как приложение читает настройки. Разницу видно на паре соседних
+конечных точек: `/demo/greeting` работает с объектом секции, `/demo/greeting/{name}` —
+с сервисом и его собственным аргументом.
+
+Вызовы пакетов — `AddConfiguredCorsPolicy()`, `AddConfiguredOpenApiViaSwagger()`
+и остальные — в `AppConfiguration/` **не** заворачивались и остались в `Program.cs`
+на виду. Обёртка сократила бы `Program.cs`, но спрятала бы ровно то, ради чего образец
+и существует: чтобы увидеть, как подключается CORS, пришлось бы открывать другой файл.
 
 ## Почему адреса в `SwaggerAppSettings.Servers` относительные
 
@@ -59,11 +105,17 @@ dotnet run --project samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api
 - **`AndreyAkaSkif.ServiceDefaults.PostgreSQL`** — требует запущенного PostgreSQL, поэтому
   выключен: иначе пример перестал бы запускаться одной командой.
 
-Чтобы включить любой из блоков, нужно раскомментировать `ProjectReference` в
-[csproj](src/AndreyAkaSkif.ServiceDefaults.Samples.Api/AndreyAkaSkif.ServiceDefaults.Samples.Api.csproj),
-блок в [Program.cs](src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Program.cs) вместе с его
-`using`-ами, а для PostgreSQL — ещё и секцию `ConnectionStrings` в
-`appsettings.Development.json`. Оба варианта компилируются.
+В обоих случаях нужно раскомментировать `ProjectReference` в
+[csproj](src/AndreyAkaSkif.ServiceDefaults.Samples.Api/AndreyAkaSkif.ServiceDefaults.Samples.Api.csproj)
+и соответствующий код вместе с его `using`-ами:
+
+- для OpenApi — блок в [Program.cs](src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Program.cs),
+  это выбор пакета библиотеки, а не прикладная настройка;
+- для PostgreSQL — тело метода и класс `DemoDbContext`
+  в [AppDbContextsConfigureExtensions.cs](src/AndreyAkaSkif.ServiceDefaults.Samples.Api/AppConfiguration/AppDbContextsConfigureExtensions.cs),
+  плюс секцию `ConnectionStrings` в `appsettings.Development.json`.
+
+Оба варианта компилируются.
 
 ## Solution
 

--- a/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/AndreyAkaSkif.ServiceDefaults.Samples.Api.csproj
+++ b/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/AndreyAkaSkif.ServiceDefaults.Samples.Api.csproj
@@ -14,7 +14,7 @@
          Пакет является альтернативой AndreyAkaSkif.ServiceDefaults.Swagger -->
     <!-- <ProjectReference Include="..\..\..\src\AndreyAkaSkif.ServiceDefaults.OpenApi\AndreyAkaSkif.ServiceDefaults.OpenApi.csproj" /> -->
 
-    <!-- Раскомментировать вместе с блоком PostgreSQL в Program.cs -->
+    <!-- Раскомментировать вместе с содержимым AppConfiguration\AppDbContextsConfigureExtensions.cs -->
     <!-- <ProjectReference Include="..\..\..\src\AndreyAkaSkif.ServiceDefaults.PostgreSQL\AndreyAkaSkif.ServiceDefaults.PostgreSQL.csproj" /> -->
   </ItemGroup>
 

--- a/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/AppConfiguration/AppDbContextsConfigureExtensions.cs
+++ b/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/AppConfiguration/AppDbContextsConfigureExtensions.cs
@@ -1,0 +1,39 @@
+namespace AndreyAkaSkif.ServiceDefaults.Samples.Api.AppConfiguration;
+
+/// <summary>
+/// Контексты базы данных
+/// </summary>
+internal static class AppDbContextsConfigureExtensions
+{
+    /// <summary>
+    /// Зарегистрировать контексты базы данных
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// В образце контекст выключен: он требует запущенного PostgreSQL, а образец должен
+    /// запускаться одной командой. Пакет
+    /// <c>AndreyAkaSkif.ServiceDefaults.PostgreSQL</c> подключает контекст EF Core
+    /// на Npgsql одним вызовом, строка подключения читается из
+    /// <c>ConnectionStrings:DefaultConnection</c> — имя фиксировано в пакете.
+    /// </para>
+    /// <para>
+    /// Чтобы включить, нужно раскомментировать: <c>ProjectReference</c>
+    /// на <c>AndreyAkaSkif.ServiceDefaults.PostgreSQL</c> в csproj, секцию
+    /// <c>ConnectionStrings</c> в appsettings.Development.json, а в этом файле —
+    /// <c>using</c>-и, тело метода и класс <c>DemoDbContext</c>.
+    /// </para>
+    /// </remarks>
+    public static IHostApplicationBuilder AddAppDbContexts(this IHostApplicationBuilder builder)
+    {
+        // builder.AddSimplePostgreSQLContext<DemoDbContext>();
+
+        return builder;
+    }
+}
+
+// Парная часть блока PostgreSQL. Требует using-ов Microsoft.EntityFrameworkCore
+// и AndreyAkaSkif.ServiceDefaults.PostgreSQL:
+//
+// internal sealed class DemoDbContext(DbContextOptions<DemoDbContext> options) : DbContext(options)
+// {
+// }

--- a/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/AppConfiguration/AppRouteConstraintsConfigureExtensions.cs
+++ b/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/AppConfiguration/AppRouteConstraintsConfigureExtensions.cs
@@ -1,0 +1,33 @@
+using AndreyAkaSkif.ServiceDefaults.Routing;
+using AndreyAkaSkif.ServiceDefaults.Samples.Api.Endpoints;
+
+namespace AndreyAkaSkif.ServiceDefaults.Samples.Api.AppConfiguration;
+
+/// <summary>
+/// Ограничения параметров маршрута, специфичные для приложения
+/// </summary>
+internal static class AppRouteConstraintsConfigureExtensions
+{
+    /// <summary>
+    /// Зарегистрировать ограничения параметров маршрута
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Сюда добавляются ограничения для собственных типов приложения: перечисления
+    /// через <c>AddEnumRouteConstraint</c> и любые свои реализации <c>IRouteConstraint</c>
+    /// через <c>AddRouteConstraint</c>.
+    /// </para>
+    /// <para>
+    /// Ограничение <c>DemoChannel</c> доступно в шаблоне маршрута как "demoChannel" —
+    /// имя по умолчанию берётся от имени типа. Заодно включается сериализация
+    /// перечислений именами, иначе в теле ответа и в спецификации они выглядели бы
+    /// как 0, 1, 2.
+    /// </para>
+    /// </remarks>
+    public static IHostApplicationBuilder AddAppRouteConstraints(this IHostApplicationBuilder builder)
+    {
+        builder.AddEnumRouteConstraint<DemoChannel>();
+
+        return builder;
+    }
+}

--- a/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/AppConfiguration/AppServicesConfigureExtensions.cs
+++ b/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/AppConfiguration/AppServicesConfigureExtensions.cs
@@ -1,0 +1,42 @@
+using AndreyAkaSkif.ServiceDefaults.Samples.Api.AppSettings;
+using AndreyAkaSkif.ServiceDefaults.Samples.Api.Services;
+
+namespace AndreyAkaSkif.ServiceDefaults.Samples.Api.AppConfiguration;
+
+/// <summary>
+/// Сервисы приложения
+/// </summary>
+internal static class AppServicesConfigureExtensions
+{
+    /// <summary>
+    /// Зарегистрировать сервисы приложения
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Сюда складываются регистрации репозиториев, сервисов домена, валидаторов
+    /// и прочих зависимостей приложения.
+    /// </para>
+    /// <para>
+    /// Здесь же граничные настройки отображаются в аргументы домена:
+    /// <see cref="DemoAppSettings"/> знает про секцию конфигурации,
+    /// <see cref="GreetingServiceArgs"/> — нет, и переход между ними происходит
+    /// в composition root, а не внутри сервиса. Если аргумент не зависит от других
+    /// сервисов, его можно собрать сразу и зарегистрировать короче:
+    /// <c>builder.AddServiceArg(new GreetingServiceArgs("Привет"))</c>.
+    /// </para>
+    /// <para>
+    /// Когда регистраций становится много, этот файл делится по темам —
+    /// рядом появляются соседи вроде <c>AppValidatorsConfigureExtensions</c>,
+    /// а <c>Program.cs</c> при этом не растёт.
+    /// </para>
+    /// </remarks>
+    public static IHostApplicationBuilder AddAppServices(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddSingleton(sp =>
+            new GreetingServiceArgs(sp.GetRequiredService<DemoAppSettings>().Greeting));
+
+        builder.Services.AddSingleton<IGreetingService, GreetingService>();
+
+        return builder;
+    }
+}

--- a/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/AppConfiguration/AppSettingsConfigureExtensions.cs
+++ b/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/AppConfiguration/AppSettingsConfigureExtensions.cs
@@ -1,0 +1,32 @@
+using AndreyAkaSkif.ServiceDefaults.Samples.Api.AppSettings;
+using AndreyAkaSkif.ServiceDefaults.Settings;
+
+namespace AndreyAkaSkif.ServiceDefaults.Samples.Api.AppConfiguration;
+
+/// <summary>
+/// Настройки приложения
+/// </summary>
+internal static class AppSettingsConfigureExtensions
+{
+    /// <summary>
+    /// Зарегистрировать объекты настроек приложения
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Сюда добавляются все собственные типы настроек приложения. Каждый читается
+    /// из одноимённой секции конфигурации, валидируется в момент вызова — то есть
+    /// до <c>Build()</c> — и попадает в DI-контейнер готовым экземпляром.
+    /// </para>
+    /// <para>
+    /// Это типы границы приложения; они лежат в каталоге <c>AppSettings</c>.
+    /// Объекты-параметры сервисов сюда не относятся — их место рядом с сервисом,
+    /// см. <c>AppServicesConfigureExtensions</c>.
+    /// </para>
+    /// </remarks>
+    public static IHostApplicationBuilder AddAppSettings(this IHostApplicationBuilder builder)
+    {
+        builder.AddServiceArgFromValidatedSettingsObject<DemoAppSettings>();
+
+        return builder;
+    }
+}

--- a/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/AppSettings/DemoAppSettings.cs
+++ b/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/AppSettings/DemoAppSettings.cs
@@ -1,10 +1,16 @@
 using AndreyAkaSkif.ServiceDefaults.Settings;
 
-namespace AndreyAkaSkif.ServiceDefaults.Samples.Api.Settings;
+namespace AndreyAkaSkif.ServiceDefaults.Samples.Api.AppSettings;
 
 /// <summary>
 /// Настройки приложения. Секция конфигурации называется так же, как тип
 /// </summary>
+/// <remarks>
+/// Объект границы приложения: знает имя секции конфигурации и реализует
+/// <see cref="IValidatableSettingsObject"/>. Домену такой тип отдавать не обязательно —
+/// сервис объявляет собственный объект-параметр рядом с собой, см.
+/// <c>Services/GreetingServiceArgs.cs</c>
+/// </remarks>
 public sealed record DemoAppSettings : IValidatableSettingsObject
 {
     public string Greeting { get; init; } = string.Empty;

--- a/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Endpoints/DemoEndpoints.cs
+++ b/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Endpoints/DemoEndpoints.cs
@@ -1,4 +1,5 @@
-using AndreyAkaSkif.ServiceDefaults.Samples.Api.Settings;
+using AndreyAkaSkif.ServiceDefaults.Samples.Api.AppSettings;
+using AndreyAkaSkif.ServiceDefaults.Samples.Api.Services;
 
 namespace AndreyAkaSkif.ServiceDefaults.Samples.Api.Endpoints;
 
@@ -19,6 +20,14 @@ internal static class DemoEndpoints
         demo.MapGet("/greeting", (DemoAppSettings settings) => Results.Ok(new { settings.Greeting }))
             .WithName("GetGreeting")
             .WithSummary("Приветствие из секции конфигурации DemoAppSettings");
+
+        // Соседняя точка показывает вторую роль: сервис получает не DemoAppSettings,
+        // а собственный GreetingServiceArgs, который лежит рядом с ним и про
+        // конфигурацию ничего не знает. Связывает их AddAppServices()
+        demo.MapGet("/greeting/{name}", (string name, IGreetingService greetings) =>
+                Results.Ok(new { greeting = greetings.Greet(name) }))
+            .WithName("GetPersonalGreeting")
+            .WithSummary("Приветствие по имени: сервис с собственным объектом-параметром");
 
         demo.MapGet("/echo", (string message) => Results.Ok(new { message }))
             .WithName("GetEcho")

--- a/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Program.cs
+++ b/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Program.cs
@@ -2,10 +2,9 @@ using AndreyAkaSkif.ServiceDefaults.Cors;
 using AndreyAkaSkif.ServiceDefaults.ErrorHandling;
 using AndreyAkaSkif.ServiceDefaults.HealthChecking;
 using AndreyAkaSkif.ServiceDefaults.Routing;
+using AndreyAkaSkif.ServiceDefaults.Samples.Api.AppConfiguration;
 using AndreyAkaSkif.ServiceDefaults.Samples.Api.Endpoints;
-using AndreyAkaSkif.ServiceDefaults.Samples.Api.Settings;
 using AndreyAkaSkif.ServiceDefaults.Serilog;
-using AndreyAkaSkif.ServiceDefaults.Settings;
 using AndreyAkaSkif.ServiceDefaults.Swagger;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -14,9 +13,11 @@ var builder = WebApplication.CreateBuilder(args);
 // По умолчанию Serilog ставится монопольно: провайдеры по умолчанию не пишут
 builder.AddConfiguredLoggingViaSerilog();
 
-// Настройки приложения: секция "DemoAppSettings" валидируется здесь же,
-// до Build(), и регистрируется в DI
-builder.AddServiceArgFromValidatedSettingsObject<DemoAppSettings>();
+// Конфигурация, специфичная для приложения. Подробности — в каталоге AppConfiguration
+builder.AddAppSettings();
+builder.AddAppDbContexts();
+builder.AddAppServices();
+builder.AddAppRouteConstraints();
 
 // ProblemDetails. В Development в ответ добавляется поле "exception"
 builder.AddExtendedErrorHandling();
@@ -30,11 +31,6 @@ builder.AddConfiguredCorsPolicy();
 // Конечная точка /health и её отображение в Swagger UI
 builder.AddHealthCheckEndpointWithSwagger();
 
-// Перечисление как сегмент пути: ограничение доступно в шаблоне как "demoChannel" —
-// имя по умолчанию от имени типа. Заодно включается сериализация перечислений
-// именами, иначе в теле ответа и в спецификации они выглядели бы как 0, 1, 2
-builder.AddEnumRouteConstraint<DemoChannel>();
-
 // --- OpenApi без Swagger -----------------------------------------------------
 // Альтернатива паре AddConfiguredOpenApiViaSwagger/UseConfiguredOpenApiViaSwagger:
 // встроенная в ASP.NET генерация спецификации без Swagger UI.
@@ -43,16 +39,6 @@ builder.AddEnumRouteConstraint<DemoChannel>();
 // AndreyAkaSkif.ServiceDefaults.OpenApi и убрать вызовы Swagger:
 //
 // builder.AddDefaultOpenApi();
-// -----------------------------------------------------------------------------
-
-// --- PostgreSQL --------------------------------------------------------------
-// Чтобы включить — раскомментировать ProjectReference на
-// AndreyAkaSkif.ServiceDefaults.PostgreSQL в csproj, секцию "ConnectionStrings"
-// в appsettings.Development.json, using-и Microsoft.EntityFrameworkCore и
-// AndreyAkaSkif.ServiceDefaults.PostgreSQL, а также класс DemoDbContext
-// в конце файла. Требуется запущенный PostgreSQL:
-//
-// builder.AddSimplePostgreSQLContext<DemoDbContext>();
 // -----------------------------------------------------------------------------
 
 var app = builder.Build();
@@ -70,10 +56,3 @@ app.MapHealthCheckEndpoint();
 // app.UseDefaultOpenApi();
 
 app.Run();
-
-// Парная часть блока "PostgreSQL". Строка подключения читается из
-// ConnectionStrings:DefaultConnection — имя фиксировано в пакете:
-//
-// internal sealed class DemoDbContext(DbContextOptions<DemoDbContext> options) : DbContext(options)
-// {
-// }

--- a/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Services/GreetingService.cs
+++ b/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Services/GreetingService.cs
@@ -1,0 +1,12 @@
+namespace AndreyAkaSkif.ServiceDefaults.Samples.Api.Services;
+
+/// <inheritdoc cref="IGreetingService"/>
+/// <remarks>
+/// Зависит от <see cref="GreetingServiceArgs"/> — собственного типа домена, а не от
+/// объекта секции конфигурации. Благодаря этому сервис остаётся независимым от того,
+/// как приложение читает настройки
+/// </remarks>
+internal sealed class GreetingService(GreetingServiceArgs args) : IGreetingService
+{
+    public string Greet(string name) => $"{args.Greeting}, {name}!";
+}

--- a/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Services/GreetingServiceArgs.cs
+++ b/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Services/GreetingServiceArgs.cs
@@ -1,0 +1,14 @@
+namespace AndreyAkaSkif.ServiceDefaults.Samples.Api.Services;
+
+/// <summary>
+/// Аргументы <see cref="GreetingService"/>
+/// </summary>
+/// <remarks>
+/// Лежит рядом с сервисом, а не среди объектов настроек: это часть домена. Тип не знает
+/// ни про <c>IOptions</c>, ни про имена секций конфигурации, ни про
+/// <c>IValidatableSettingsObject</c> — он лишь объявляет, что сервису нужно для работы.
+/// Откуда возьмётся значение, решает composition root, см.
+/// <c>AppConfiguration/AppServicesConfigureExtensions.cs</c>
+/// </remarks>
+/// <param name="Greeting">Приветствие, которым сервис открывает обращение</param>
+internal sealed record GreetingServiceArgs(string Greeting);

--- a/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Services/IGreetingService.cs
+++ b/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Services/IGreetingService.cs
@@ -1,0 +1,13 @@
+namespace AndreyAkaSkif.ServiceDefaults.Samples.Api.Services;
+
+/// <summary>
+/// Составляет персональное приветствие
+/// </summary>
+internal interface IGreetingService
+{
+    /// <summary>
+    /// Поприветствовать по имени
+    /// </summary>
+    /// <param name="name">Имя адресата</param>
+    string Greet(string name);
+}


### PR DESCRIPTION
Прикладные регистрации убраны из Program.cs в методы расширения каталога AppConfiguration: AddAppSettings, AddAppDbContexts, AddAppServices и AddAppRouteConstraints. Вызовы пакетов библиотеки оставлены в Program.cs на виду — образец существует ради демонстрации её API.

Закомментированный блок PostgreSQL и класс DemoDbContext, лежавшие в Program.cs порознь, собраны в AppDbContextsConfigureExtensions; ссылка на них в комментарии csproj поправлена.

Каталог Settings переименован в AppSettings: внутри namespace ...Samples.Api.* имя Settings разрешалось в ...Samples.Api.Settings раньше, чем в AndreyAkaSkif.ServiceDefaults.Settings.

Добавлен GreetingService с собственным объектом-параметром GreetingServiceArgs и конечная точка /demo/greeting/{name}. В паре с /demo/greeting она показывает разницу между объектом секции конфигурации и объектом-параметром сервиса, который лежит рядом с сервисом и про конфигурацию не знает.

В samples/README.md добавлены разделы о раскладке кода и о двух ролях объектов настроек.

Closes #77