### PR TITLE
docs: сайт документации DocFX

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "docfx": {
+      "version": "2.78.5",
+      "commands": [
+        "docfx"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+# Документация (DocFX → GitHub Pages): деплой на пуш в master и по ручному запуску.
+# Дока развязана с релизом пакетов — отражает текущий master, включая правки README
+# между релизами. Статьи сайта — это те же README, отдельных копий нет.
+name: docs
+
+on:
+    push:
+        branches: [master]
+    workflow_dispatch:
+
+env:
+    DOTNET_VERSION: '10.0.x'
+
+# Разрешаем один активный деплой Pages за раз; новые пуши в master не отменяют текущий.
+concurrency:
+    group: pages
+    cancel-in-progress: false
+
+jobs:
+    deploy-docs:
+        runs-on: ubuntu-latest
+        permissions:
+            pages: write
+            id-token: write
+            contents: read
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        steps:
+            - name: 🛒 Checkout
+              uses: actions/checkout@v7
+
+            - name: ✨ Setup .NET
+              uses: actions/setup-dotnet@v6
+              with:
+                dotnet-version: ${{ env.DOTNET_VERSION }}
+
+            - name: 🧰 Restore .NET tools
+              run: dotnet tool restore
+
+            # Справочник API строится из проектов src/, поэтому шагу нужен restore
+            - name: 📖 Build documentation
+              run: dotnet docfx docs/docfx.json
+
+            - name: 📄 Setup Pages
+              uses: actions/configure-pages@v6
+
+            - name: 📤 Upload Pages artifact
+              uses: actions/upload-pages-artifact@v5
+              with:
+                path: docs/_site
+
+            - name: 🚀 Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -426,3 +426,7 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+
+# DocFX (генерируемая документация)
+docs/_site/
+docs/api/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # <img alt="logo" src="./logo/logo.png" width="32"/> Базовая конфигурация WEB-API сервисов ASP.NET
 
-[![GitHub license](https://img.shields.io/github/license/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults.svg)](https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/blob/master/LICENSE)
 [![CI](https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/actions/workflows/ci.yml/badge.svg)](https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/actions/workflows/ci.yml)
 [![Release](https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/actions/workflows/release.yml/badge.svg)](https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/actions/workflows/release.yml)
+[![GitHub license](https://img.shields.io/github/license/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults.svg)](https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/blob/master/LICENSE)
+[![Docs](https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/actions/workflows/docs.yml/badge.svg)](https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/actions/workflows/docs.yml)
 
 Набор вспомогательных библиотек для упрощённой конфигурации ASP.NET Web-API сервисов.  
 Проект предоставляет методы расширения для настройки:
@@ -20,7 +21,7 @@
 
 Идея вдохновлена проектом [eShop.ServiceDefaults](https://github.com/dotnet/eShop/tree/main/src/eShop.ServiceDefaults) из [eShop Reference Application](https://github.com/dotnet/eShop).
 
-## 📦 Состав пакетов
+## Состав пакетов
 
 Репозиторий содержит пять NuGet-пакетов. Базовым является `AndreyAkaSkif.ServiceDefaults`;
 остальные подключаются по мере надобности.
@@ -39,7 +40,7 @@
 
 ---
 
-## 📚 Документация и примеры
+## Документация и примеры
 
 Каждый пакет содержит свой отдельный README с:
 
@@ -47,22 +48,27 @@
 - минимальными примерами интеграции,
 - описанием секций конфигурации.
 
-👉 Запускаемый пример сервиса, собранного на этих пакетах: [`samples/README.md`](./samples/README.md)
+Запускаемый пример сервиса, собранного на этих пакетах: [`samples/README.md`](./samples/README.md)
 
 ---
 
-## 🚧 В планах
+## Просмотр документации
 
-- [документация DocFX](https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/issues/22).
+Документация проекта создана с помощью инструмента [DocFX](https://github.com/dotnet/docfx).
+Сгенерированная документация расположена на сервисе
+[github.io](https://andrey-aka-skif.github.io/AndreyAkaSkif.ServiceDefaults/): те же статьи
+плюс справочник API, собранный из XML-комментариев.
+
+Для просмотра локальной документации использовать команды
+(docfx подключён как локальный инструмент):
+
+```shell
+dotnet tool restore
+dotnet docfx docs/docfx.json --serve
+```
 
 ---
 
-## 🐞 Сообщить о проблеме
+## Лицензия
 
-https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/issues
-
----
-
-## 📄 Лицензия
-
-[MIT](./LICENSE)
+[MIT](https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/blob/master/LICENSE)

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -1,0 +1,18 @@
+- name: Обзор
+  href: ../../README.md
+
+- name: Пакеты
+  items:
+  - name: ServiceDefaults
+    href: ../../src/AndreyAkaSkif.ServiceDefaults/README.md
+  - name: ServiceDefaults.OpenApi
+    href: ../../src/AndreyAkaSkif.ServiceDefaults.OpenApi/README.md
+  - name: ServiceDefaults.Swagger
+    href: ../../src/AndreyAkaSkif.ServiceDefaults.Swagger/README.md
+  - name: ServiceDefaults.PostgreSQL
+    href: ../../src/AndreyAkaSkif.ServiceDefaults.PostgreSQL/README.md
+  - name: ServiceDefaults.Serilog
+    href: ../../src/AndreyAkaSkif.ServiceDefaults.Serilog/README.md
+
+- name: Пример сервиса
+  href: ../../samples/README.md

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/docfx/main/schemas/docfx.schema.json",
+  "metadata": [
+    {
+      "src": [
+        {
+          "src": "../src",
+          "files": [
+            "**/*.csproj"
+          ]
+        }
+      ],
+      "dest": "api"
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [
+          "**/*.{md,yml}"
+        ],
+        "exclude": [
+          "_site/**"
+        ]
+      },
+      {
+        "src": "..",
+        "files": [
+          "README.md",
+          "samples/README.md",
+          "src/*/README.md"
+        ],
+        "dest": "articles"
+      }
+    ],
+    "resource": [
+      {
+        "src": "..",
+        "files": [
+          "logo/logo.png"
+        ],
+        "dest": "articles"
+      }
+    ],
+    "output": "_site",
+    "template": [
+      "default",
+      "modern"
+    ],
+    "globalMetadata": {
+      "_appName": "AndreyAkaSkif.ServiceDefaults",
+      "_appTitle": "AndreyAkaSkif.ServiceDefaults",
+      "_enableSearch": true,
+      "pdf": false
+    }
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+---
+redirect_url: articles/README.html
+---

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,0 +1,5 @@
+- name: Руководство
+  href: articles/
+
+- name: API
+  href: api/

--- a/samples/README.md
+++ b/samples/README.md
@@ -135,13 +135,13 @@ Infrastructure/         адаптеры к внешнему миру
   выключен: иначе пример перестал бы запускаться одной командой.
 
 В обоих случаях нужно раскомментировать `ProjectReference` в
-[csproj](src/AndreyAkaSkif.ServiceDefaults.Samples.Api/AndreyAkaSkif.ServiceDefaults.Samples.Api.csproj)
+[csproj](https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/blob/master/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/AndreyAkaSkif.ServiceDefaults.Samples.Api.csproj)
 и соответствующий код вместе с его `using`-ами:
 
-- для OpenApi — блок в [Program.cs](src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Program.cs),
+- для OpenApi — блок в [Program.cs](https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/blob/master/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/Program.cs),
   это выбор пакета библиотеки, а не прикладная настройка;
 - для PostgreSQL — тело метода и класс `DemoDbContext`
-  в [AppDbContextsConfigureExtensions.cs](src/AndreyAkaSkif.ServiceDefaults.Samples.Api/AppConfiguration/AppDbContextsConfigureExtensions.cs),
+  в [AppDbContextsConfigureExtensions.cs](https://github.com/andrey-aka-skif/AndreyAkaSkif.ServiceDefaults/blob/master/samples/src/AndreyAkaSkif.ServiceDefaults.Samples.Api/AppConfiguration/AppDbContextsConfigureExtensions.cs),
   плюс секцию `ConnectionStrings` в `appsettings.Development.json`.
 
 Оба варианта компилируются.


### PR DESCRIPTION
Closes #22

Сайт документации DocFX по образцу ServiceResult: источник в `docs/`, вывод в `docs/_site` (в репозиторий не попадает), docfx как локальный dotnet-tool, деплой в GitHub Pages из workflow.

Ключевое отличие от ServiceResult: **статьи не переписывались**. DocFX подключает существующие README (корневой, пять пакетных, пример) как контент напрямую — один источник правды, дрейф между сайтом и GitHub невозможен by design. Лендинг редиректом уходит на страницу корневого README.

## Состав

| Файл | Назначение |
| ---- | ---------- |
| `.config/dotnet-tools.json` | docfx 2.78.5 как локальный tool |
| `docs/docfx.json` | контент из README корня репозитория (`dest: articles`) + справочник API из XML-комментариев `src/` |
| `docs/toc.yml` | навбар: Руководство / API |
| `docs/articles/toc.yml` | сайдбар: Обзор, пять пакетов, Пример сервиса |
| `docs/index.md` | редирект на `articles/README.html` |
| `.github/workflows/docs.yml` | сборка и деплой в Pages на пуш в `master` и по `workflow_dispatch` |

README: добавлены бейдж `Docs` и раздел «Просмотр документации», убраны эмодзи из заголовков и разделы «В планах» / «Сообщить о проблеме».

Ссылки на `LICENSE` и на файлы исходников примера заменены абсолютными GitHub-ссылками: относительные ведут в 404 на сгенерированных страницах, абсолютные работают на обеих площадках.

## Проверка

Чистая локальная сборка — 0 warnings, 0 errors. На локальном сервере: корень редиректит на «Обзор», все семь статей и все ссылки внутри них отдают 200, логотип на месте, раздел API содержит десять namespace'ов из всех пяти пакетов, поиск находит `AddConfiguredCorsPolicy`.

Единственный 404 — хлебная крошка на пустой namespace `AndreyAkaSkif` на страницах API; это поведение самого DocFX, на опубликованном сайте ServiceResult ровно то же самое.

## Перед мержем

Нужно один раз включить **Settings → Pages → Source: GitHub Actions** — сейчас Pages у репозитория не активированы, без этого шаг деплоя упадёт.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
